### PR TITLE
Failsafe for Null as an example

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ function filter(obj,options) {
     let filtered = {};
     recurse(src,{},function(obj,key,state){
         for (let tag of options.tags) {
-            if (obj[key][tag]) {
+            if (obj[key] && obj[key][tag]) {
                 if (options.inverse) {
                     jptr(filtered,state.path,clone(obj[key]));
                 }


### PR DESCRIPTION
This prevents the module to crash due to smth among the lines of the following:

```yaml
    RFC3339DateNullable:
      type: string
      nullable: true
      format: 'date-time'
      example: null
```