### PR TITLE
Feature - filter by OAuth scopes rather than `x-internal` flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Options:
   --inverse, -i    output filtered elements only                       [boolean]
   --flags, -f      flags to filter by          [array] [default: ["x-internal"]]
   --flagValues, -v flag String values to match             [array] [default: []]
+  --scopes          filter based upon oauth security scheme scopes, instead of
+                    'x-internal' flags                                   [array]
   --checkTags      filter if flags given in --flags are in the tags array
                                                                        [boolean]
   --overrides, -o  prefixes used to override named properties[arr] [default: []]

--- a/TeRito-OpenAPI-organisation.yaml
+++ b/TeRito-OpenAPI-organisation.yaml
@@ -1,0 +1,7521 @@
+openapi: 3.0.2
+info:
+  version: v3.2-rc2
+  title: Te Rito APIs
+  description: >
+    **Derived from:** SIF Data Model (New Zealand) v3.2 (rc2)
+
+
+    **Release Date:** 22-Oct-2020
+
+    # Te Rito Data Domains
+
+
+    <p>
+      <img src="domains/zone512.png" usemap="#DomainMap" />
+      <map id="DomainMap" name="DomainMap">
+        <area title="Organisation" href="TeRito-OpenAPI-organisation.html#tag/OrganisationOverview" shape="rect" coords="71,65,166,126" />
+        <area title="Student &amp; Whānau" href="TeRito-OpenAPI-whanau.html#tag/StudentWhanauOverview" shape="rect" coords="284,331,375,390" />
+        <area title="Enrolment" href="TeRito-OpenAPI-enrolment.html#tag/EnrolmentOverview" shape="rect" coords="206,0,301,60" />
+        <area title="Hauora / Wellbeing" href="TeRito-OpenAPI-hauora.html#tag/HauoraWellbeingOverview" shape="rect" coords="37,214,132,273" />
+        <area title="Aromatawai / Assessment" href="TeRito-OpenAPI-aromatawai.html#tag/AromatawaiAssessmentOverview" shape="rect" coords="378,214,471,272" />
+        <area title="Timetable" href="TeRito-OpenAPI-attendance.html#tag/ScheduleAttendanceOverview" shape="rect" coords="132,333,221,391" />
+        <area title="Attendance" href="TeRito-OpenAPI-attendance.html#tag/ScheduleAttendanceOverview" shape="rect" coords="344,65,437,126" />
+      </map>
+    </p>
+
+
+    Te Rito implements the following SIF Domains:
+      - [Organisation & Staff](TeRito-OpenAPI-organisation.html#tag/OrganisationOverview)
+      - [Timetable](TeRito-OpenAPI-attendance.html#tag/ScheduleAttendanceOverview)
+      - [Student & Whānau](TeRito-OpenAPI-whanau.html#tag/StudentWhanauOverview)
+      - [Enrolment](TeRito-OpenAPI-enrolment.html#tag/EnrolmentOverview)
+      - [Attendance](TeRito-OpenAPI-attendance.html#tag/ScheduleAttendanceOverview)
+      - [Aromatawai/Assessment](TeRito-OpenAPI-aromatawai.html#tag/AromatawaiAssessmentOverview)
+      - [Hauora/Wellbeing](TeRito-OpenAPI-hauora.html#tag/HauoraWellbeingOverview)
+  contact:
+    name: Ministry of Education
+    url: http://www.terito.govt.nz
+    email: terito@education.govt.nz
+  x-logo:
+    url: http://www.terito.govt.nz/themes/custom/education_drupal_theme/assets/images/Te_rito_greenflax.svg
+    backgroundColor: null
+    altText: Te Rito Logo
+servers:
+  - url: https://southern.edsby.co.nz/sif
+    description: The demonstration Te Rito server
+  - url: https://nzqa.edsby.co.nz/sif
+    description: The NZ Quality Assurance Te Rito server (daily updates)
+  - url: https://northern.edsby.co.nz/sif
+    description: The Integration Test Te Rito server (end of sprint updates)
+security:
+  - sifDataObject:
+      - DEFERRED
+x-tagGroups:
+  - name: Organisation
+    x-displayName: Organisation Domain
+    tags:
+      - OrganisationOverview
+      - Search
+      - Organisation
+      - OrganisationRelationship
+      - StaffPersonal
+      - StaffAssignment
+      - StaffTeachingGroupAssignment
+      - TeachingGroup
+      - AcademicDepartment
+      - ProviderCourse
+tags:
+  - name: OrganisationOverview
+    x-displayName: Organisation Overview
+    description: >-
+      <p> The Organisation domain describes education provider entities (ECEs,
+      Schools &amp; Tertiary Education Institutions), Communities (Kāhui Ako,
+      Learning Support Clusters, etc.) the relationships between them, and the
+      Staff that work at them.</p> <img
+      src="domains/SIFNZ-LogicalModel-OrganisationDomain.png"
+      usemap="#OrganisationMap" /> <map title="OrganisationMap"
+      name="OrganisationMap">
+        <area title="Organisation" shape="rect" coords="386,44,602,127" href="#tag/Organisation" />
+        <area title="OrganisationRelationship" shape="rect" coords="656,142,789,199" href="#tag/OrganisationRelationship" />
+        <area title="StaffPersonal" shape="rect" coords="466,472,555,536" href="#tag/StaffPersonal" />
+        <area title="StaffAssignment" shape="rect" coords="664,212,754,284" href="#tag/StaffAssignment" />
+        <area title="StaffTeachingGroupAssignment" shape="rect" coords="38,263,215,303" href="#tag/StaffTeachingGroupAssignment" />
+        <area title="ProviderCourse" shape="rect" coords="387,284,476,320" href="#tag/ProviderCourse" />
+        <area title="TeachingGroup" shape="rect" coords="215,65,305,107" href="#tag/TeachingGroup" />
+        <area title="AcademicDepartment" shape="rect" coords="196,392,316,427" href="#tag/AcademicDepartment" />
+      </map>  
+  - name: Search
+    x-displayName: Search
+    description: Search operation returning partial <a
+      href="#tag/StaffPersonal">StaffPersonal</a> and <a
+      href="#tag/StudentPersonal">StudentPersonal</a> objects.
+  - name: Organisation
+    x-displayName: Organisation
+    description: Operations on recognised Education Provider entities (ECEs, Schools &
+      Tertiary  Education Institutions), Communities (Kāhui Ako, Learning
+      Support Clusters, etc.), and  others (Teen Parent Units, Activity Centres.
+      etc.)
+  - name: OrganisationRelationship
+    x-displayName: Organisation Relationship
+    description: <p>Operations on recognised relationships between two education
+      Organisations. The two organisations are referred to as the Source
+      Organisation and the Related Organisation.</p> <p>RelationshipType records
+      the nature of the relationship between the two organisations, and gives
+      guidance on which is the Source Organisation and which is the Related
+      Organisation.</p>
+  - name: StaffPersonal
+    x-displayName: Staff Personal
+    description: >-
+      <p>Operations on the personal contact and demographic information relating
+      to
+
+      staff members, who might be a teacher or other employee of a Provider.</p>
+
+
+      <p>Searching for staff personal record by name, email address (or whatever) is
+
+      available via <a href="#tag/Search">Te Rito Search API</a>.</p>
+
+
+      <p>Non personal information relating to the staff member's relationship with Providers
+
+      is stored in the <a href="#tag/StaffAssignment">StaffAssignment</a> data object.</p>
+  - name: StaffAssignment
+    x-displayName: Staff Assignment
+    description: >-
+      <p>Operations on the assignment of a Staff member to their role at a
+      Providers or other 
+
+      Organisation. A staff member may have only have a single role at each Provider or Kāhui Ako at any one time 
+
+      (via the Organisation data object)</p>
+
+      <p>Role assignments can be restricted to categories of Students with the StaffSubjectList and
+       YearLevelList. This allows for assignment to roles with particular responsibility for general 
+       cohorts of students, such as "Head of Department (Maths)" or "Year 8 Student Dean".</p> 
+       <p>While assignment to student contact roles such as Subject Teacher, Homeroom Teacher, 
+       Whānau Teacher or House Master is made with this data object; Details of the particular group 
+       of specific students the staff member is responsible for are made via the 
+       <a href="#tag/TeachingGroup">TeachingGroup</a> data object.</p>
+  - name: StaffTeachingGroupAssignment
+    x-displayName: Staff Teaching Group Assignment
+    description: <p>Operations on the assignment of a Staff member to a particular role
+      with a particular TeachingGroup at a Provider</p>
+  - name: TeachingGroup
+    x-displayName: Teaching Group
+    description: <p>Operations on teaching Classes of students. Such classes can have
+      multiple staff  assigned in a variety of roles (via <a
+      href="#tag/StaffTeachingGroupAssignment">StaffTeachingGroupAssignment</a>),  may
+      be assigned students from multiple year levels (via <a
+      href="#tag/StudentTeachingGroupEnrolment">StudentTeachingGroupEnrolment</a>),
+      and may be taught multiple <a
+      href="#tag/ProviderCourse">ProviderCourses</a>.</p>
+  - name: AcademicDepartment
+    x-displayName: Academic Department
+    description: <p>Operations on academic departments within a provider, each of which
+      groups <a href="#tagProviderCourse">ProviderCourses</a> and  <a
+      href="#tagTeachingGroup">TeachingGroups</a> according to SubjectArea.</p>
+  - name: ProviderCourse
+    x-displayName: Provider Course
+    description: <p>Operations on provider defined Courses that Students enrol in,  and may
+      be assessed for, and achieve passes in.</p>
+paths:
+  /search:
+    get:
+      tags:
+        - Search
+      summary: Search for Staff and Students
+      description: >-
+        Search operation returning partial <a
+        href="#tag/StaffPersonal">StaffPersonal</a>
+
+        and <a href="#tag/StudentPersonal">StudentPersonal</a> objects.
+      operationId: search
+      security:
+        - sifDataObject:
+            - FIRST
+            - SUPS
+            - SMS
+      parameters:
+        - name: objects
+          in: query
+          description: "CSV delimited list of data object names; limits the search to only
+            some data objects: staffpersonal, studentpersonal"
+          required: false
+          schema:
+            type: string
+          example: StudentPersonal,StaffPersonal
+        - name: pattern
+          in: query
+          description: Select objects where search index includes the given pattern
+            pattern; `pattern=Sco*`
+          required: false
+          schema:
+            type: string
+          example: Sco*
+        - name: query
+          in: query
+          description: Use lucene query language to select objects;
+          required: false
+          schema:
+            type: string
+          example: PersonInfo.Name.GivenName:joel
+        - name: max
+          in: query
+          description: Maximum items per page, default 10,000; `max=100`; applies to any
+            call with repeated data
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+          example: 100
+        - name: page
+          in: query
+          description: Return nth page of results; default 0	`page=2`; applies to any call
+            with repeated data
+          required: false
+          schema:
+            type: integer
+            minimum: 0
+          example: 2
+        - name: human
+          in: query
+          description: For code set fields, translate code to human readable form;	`human=1`
+          required: false
+          schema:
+            type: integer
+            enum:
+              - 0
+              - 1
+          example: 1
+        - name: Accept
+          in: header
+          description: Standard HTTP accept header, choose between JSON and XML for
+            response. Defaults to XML if this header is missing.
+          required: true
+          schema:
+            type: string
+            enum:
+              - application/json
+              - application/xml
+          example: application/json
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  Search:
+                    type: object
+                    properties:
+                      Summary:
+                        type: object
+                        description: Statistical summary of the search results returned.
+                        properties:
+                          Shown:
+                            type: integer
+                            description: Count of objects returned in this response
+                          More:
+                            type: integer
+                            description: Count of objects yet to be returned, because of
+                              `max` page size limit
+                      SearchResults:
+                        type: object
+                        description: The data objects found
+                        properties:
+                          Personals:
+                            type: object
+                            description: Staff &amp; Student Personal objects found
+                            properties:
+                              StaffPersonals:
+                                type: object
+                                description: StaffPersonal objects found
+                                properties:
+                                  StaffPersonal:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        Name:
+                                          type: string
+                                          description: Full name from the search index
+                                        Rank:
+                                          type: number
+                                          description: Degree of match to search criteria
+                                        Type:
+                                          type: string
+                                          description: Internal data type of object returned
+                                        ProviderName:
+                                          type: array
+                                          description: Array of strings, being the names of
+                                            the Providers associated with the
+                                            person
+                                          items:
+                                            type: string
+                                        ProviderRefId:
+                                          type: array
+                                          description: Array of strings, being the
+                                            ProviderRefIds of the Providers
+                                            associated with the person
+                                          items:
+                                            type: string
+                                        LocalId:
+                                          type: string
+                                          description: The StaffPersonalLocalId of the
+                                            staff member located
+                                        RefId:
+                                          type: string
+                                          description: The StaffPersonalRefId of the staff
+                                            member located
+                                        ESLPairwiseId:
+                                          type: string
+                                          description: Internal user provisioning
+                                            identifier for the staff member
+                                            located
+                                        PersonInfo:
+                                          type: object
+                                          description: Partial PersonInfo object
+                                          properties:
+                                            Name:
+                                              type: object
+                                              description: Person name, in pieces and
+                                                complete
+                                              properties:
+                                                Title:
+                                                  type: string
+                                                FamilyName:
+                                                  type: string
+                                                GivenName:
+                                                  type: string
+                                                MiddleName:
+                                                  type: string
+                                                PreferredGivenName:
+                                                  type: string
+                                                Suffix:
+                                                  type: string
+                                                FullName:
+                                                  type: string
+                                            Demographics:
+                                              type: object
+                                              properties:
+                                                BirthDate:
+                                                  type: string
+                                                  format: date
+                                            EmailList:
+                                              type: object
+                                              properties:
+                                                Email:
+                                                  type: object
+                                                  properties:
+                                                    Address:
+                                                      type: string
+                              StudentPersonals:
+                                type: object
+                                properties:
+                                  StudentPersonal:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        Name:
+                                          type: string
+                                          description: Full name from the search index
+                                        Rank:
+                                          type: number
+                                          description: Degree of match to search criteria
+                                        Type:
+                                          type: string
+                                          description: Internal data type of object returned
+                                        ProviderName:
+                                          type: array
+                                          description: Array of strings, being the names of
+                                            the Providers associated with the
+                                            person
+                                          items:
+                                            type: string
+                                        ProviderRefId:
+                                          type: array
+                                          description: Array of strings, being the
+                                            ProviderRefIds of the Providers
+                                            associated with the person
+                                          items:
+                                            type: string
+                                        LocalId:
+                                          type: string
+                                          description: The StudentPersonalLocalId of the
+                                            student located
+                                        RefId:
+                                          type: string
+                                          description: The StudentPersonalRefId of the
+                                            student located
+                                        NationalStudentNumber:
+                                          type: string
+                                          description: The National Student Number of the
+                                            student located
+                                        PersonInfo:
+                                          type: object
+                                          description: Partial PersonInfo object
+                                          properties:
+                                            Name:
+                                              type: object
+                                              description: Person name, in pieces and
+                                                complete
+                                              properties:
+                                                Title:
+                                                  type: string
+                                                FamilyName:
+                                                  type: string
+                                                GivenName:
+                                                  type: string
+                                                MiddleName:
+                                                  type: string
+                                                PreferredGivenName:
+                                                  type: string
+                                                Suffix:
+                                                  type: string
+                                                FullName:
+                                                  type: string
+                                            Demographics:
+                                              type: object
+                                              properties:
+                                                BirthDate:
+                                                  type: string
+                                                  format: date
+                                                Gender:
+                                                  $ref: jsonSchema.NZ.create.yaml#/definitions/NZCodeSetsGender
+                                            EmailList:
+                                              type: object
+                                              properties:
+                                                Email:
+                                                  type: object
+                                                  properties:
+                                                    Address:
+                                                      type: string
+        "401":
+          description: Request didn't have Bearer token
+          content:
+            application/json:
+              schema:
+                type: object
+                title: error
+                required:
+                  - error
+                  - when
+                  - errorstr
+                additionalProperties: false
+                properties:
+                  error:
+                    type: integer
+                    description: Edsby defined error code
+                  when:
+                    type: string
+                    format: date-time
+                    description: Date and Time of when the HTTP request was processed.
+                  errorstr:
+                    type: string
+                    description: Narrative text describing the error
+                  refId:
+                    type: string
+                    description: Data object refId of the object being created/updated
+                  localId:
+                    type: string
+                    description: Data object localId of the object being created/updated
+              example:
+                error: 401
+                when: 2020-07-16T20:00:46.000Z
+                errorstr: "Unauthorised request: Bearer token missing??"
+        "422":
+          description: Request didn't have Accept header
+          content:
+            application/json:
+              schema:
+                type: object
+                title: error
+                required:
+                  - error
+                  - when
+                  - errorstr
+                additionalProperties: false
+                properties:
+                  error:
+                    type: integer
+                    description: Edsby defined error code
+                  when:
+                    type: string
+                    format: date-time
+                    description: Date and Time of when the HTTP request was processed.
+                  errorstr:
+                    type: string
+                    description: Narrative text describing the error
+                  refId:
+                    type: string
+                    description: Data object refId of the object being created/updated
+                  localId:
+                    type: string
+                    description: Data object localId of the object being created/updated
+              example:
+                error: 422
+                when: 2020-07-16T20:00:46.000Z
+                errorstr: "Unprocessable request: Accept or X-Edsby-OrganisationRefId
+                  header missing?? Request body invalid??  Check sl-violations
+                  header in response"
+  /organisation:
+    post:
+      tags:
+        - Organisation
+        - OrganisationBulk
+      summary: Create one or more Organisations
+      description: Bulk operation to create one or more Organisations, each of which
+        represents a single recognised Education Provider entity (ECEs, Schools
+        & Tertiary Education Institutions), Community (Kāhui Ako, Learning
+        Support Clusters, etc.), or others unit(Teen Parent Units, Activity
+        Centres. etc.)
+      operationId: createOrganisations
+      parameters:
+        - name: x-http-method-override
+          in: header
+          description: Rather than CREATE records, treat this request as a SYNC request.
+          required: false
+          schema:
+            type: string
+            oneOf:
+              - enum:
+                  - IncrementalSync
+                title: Incremental Synchronise Request
+                description: Add and Update records from the POST to ensure all records are
+                  present in the repository
+              - enum:
+                  - FullSync
+                title: Full Synchronise Request
+                description: Add, Update and **Delete** records to ensure that ONLY those
+                  records are present in the repository
+          example: IncrementalSync
+        - $ref: "#/paths/~1search/get/parameters/6"
+      security:
+        - sifDataObject:
+            - FIRST
+      requestBody:
+        description: CRUD operation on Organisation
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                Organisations:
+                  $ref: jsonSchema.NZ.create.yaml#/properties/Organisations
+            example:
+              Organisations:
+                Organisation:
+                  - OrganisationRefId: "922"
+                    OrganisationLocalId: "42342"
+                    Name: Hogwart's Area School
+                    Authority: STATE
+                    SectorRole: "35003"
+                    Type: "10030"
+                    OperationalStatus: O
+                    EntityOpen: 1652-04-01
+                    EducationRegion: "12013"
+                    SpecialEducationDistrict: "182011"
+                    AddressList:
+                      Address:
+                        - Type: RU
+                          Role: PHY
+                          Line1: 1175 Lake Ferry Rd
+                          Suburb: RD 1
+                          City: Martinborough
+                    CommunicationChannelList:
+                      Channel:
+                        - Notes: Attendance System (Self Service)
+                          Type: WEB
+                          Value: http://att.hogwarts.school.nz
+                        - Notes: School Website
+                          Type: WEB
+                          Value: http://www.hogwarts.school.nz
+                    ContactList:
+                      Contact:
+                        - Name:
+                            FamilyName: Dumbledore
+                            GivenName: Albus
+                            FullName: Albus Dumbledore
+                          PositionTitle: Headmaster
+                          Role: PRI
+                          AddressList:
+                            Address:
+                              - Type: TH
+                                Role: PHY
+                                Line1: 533 Hogwart's Way
+                                City: Hogsmead
+                                PostalCode: "7733"
+                          EmailList:
+                            Email: []
+                          PhoneNumberList:
+                            PhoneNumber: []
+                        - Name:
+                            FamilyName: Hagrid
+                            GivenName: Rubeus
+                            FullName: Rubeus Hagrid
+                          PositionTitle: Gamekeeper
+                          Role: DIR
+                          AddressList:
+                            Address:
+                              - Type: TH
+                                Role: PHY
+                                Line1: The Enchanted Wood
+                                Line2: 533 Hogwart's Way
+                                City: Hogsmead
+                                PostalCode: "7733"
+                          EmailList:
+                            Email: []
+                          PhoneNumberList:
+                            PhoneNumber: []
+                    EmailList:
+                      Email:
+                        - Type: PRIM
+                          Address: stuart@gmail.com
+                    LocationList:
+                      Location:
+                        - Description: Only Campus
+                          Address:
+                            Type: RU
+                            Role: PHY
+                            Line1: 1175 Lake Ferry Rd
+                            Suburb: RD 1
+                            City: Martinborough
+                            PostalCode: "5781"
+                          GridLocation:
+                            Latitude: -41.2814719
+                            Longitude: 175.3458472
+                          StatisticalAreaList:
+                            StatisticalArea:
+                              - SpatialUnitType: GE
+                                Code: "058"
+                              - SpatialUnitType: TA
+                                Code: "050"
+                              - SpatialUnitType: WA
+                                Code: "05003"
+                    PhoneNumberList:
+                      PhoneNumber:
+                        - Notes: Attendance Office (Automated)
+                          Usage: SMS
+                          Type: WTE
+                          Number: (0274) 300 9991
+                        - Notes: Attendance Office
+                          Usage: INT
+                          Type: WTE
+                          Number: (04) 300 9992
+                        - Notes: School Secretary DDI
+                          Type: WTE
+                          Number: (04) 300 9993
+                    SchoolService:
+                      CoEdStatus: COED
+                      Decile: 5
+                      NewEntrantPolicyList:
+                        EnactedPolicy:
+                          - EffectiveTo: 2018-12-31
+                            Policy: AE
+                          - EffectiveFrom: 2019-01-01
+                            Policy: CE
+                      SchoolYearList:
+                        SchoolYear:
+                          - YearLevel: 1
+                            FIRSTSchoolYearGenderId: 1001
+                            Gender: C
+                          - YearLevel: 2
+                            FIRSTSchoolYearGenderId: 1002
+                            Gender: C
+                          - YearLevel: 3
+                            FIRSTSchoolYearGenderId: 1003
+                            Gender: C
+                          - YearLevel: 4
+                            FIRSTSchoolYearGenderId: 1004
+                            Gender: C
+                          - YearLevel: 5
+                            FIRSTSchoolYearGenderId: 1005
+                            Gender: C
+                          - YearLevel: 6
+                            FIRSTSchoolYearGenderId: 1006
+                            Gender: C
+                          - YearLevel: 7
+                            FIRSTSchoolYearGenderId: 1007
+                            Gender: C
+                          - YearLevel: 8
+                            FIRSTSchoolYearGenderId: 1008
+                            Gender: C
+                          - YearLevel: 9
+                            FIRSTSchoolYearGenderId: 1009
+                            Gender: F
+                          - YearLevel: 10
+                            FIRSTSchoolYearGenderId: 1010
+                            Gender: F
+                          - YearLevel: 11
+                            FIRSTSchoolYearGenderId: 1011
+                            Gender: F
+                          - YearLevel: 12
+                            FIRSTSchoolYearGenderId: 1012
+                            Gender: F
+                          - YearLevel: 13
+                            FIRSTSchoolYearGenderId: 1013
+                            Gender: F
+          application/xml:
+            schema:
+              type: object
+              properties:
+                Organisations:
+                  $ref: jsonSchema.NZ.create.yaml#/properties/Organisations
+            example: |-
+              <Organisations>
+                <Organisation>
+                  <AddressList/>
+                  <CommunicationChannelList/>
+                  <ContactList>
+                    <Contact>
+                      <Name>
+                        <FamilyName>Dumbledore</FamilyName>
+                        <GivenName>Albus</GivenName>
+                        <FullName>Albus Dumbledore</FullName>
+                      </Name>
+                      <PositionTitle>Lead School Headmaster</PositionTitle>
+                      <Role>PRI</Role>
+                      <AddressList>
+                        <Address>
+                          <Type>TH</Type>
+                          <Role>PHY</Role>
+                          <Line1>533 Hogwart's Way</Line1>
+                          <City>Hogsmead</City>
+                          <PostalCode>7733</PostalCode>
+                        </Address>
+                      </AddressList>
+                      <EmailList/>
+                      <PhoneNumberList/>
+                    </Contact>
+                  </ContactList>
+                  <EmailList>
+                    <Email>
+                      <Type>PRIM</Type>
+                      <Address>hogwarts@mailinator.com</Address>
+                    </Email>
+                  </EmailList>
+                  <LocationList/>
+                  <Name>Masterton (Whakaoriori) Kāhui Ako</Name>
+                  <PhoneNumberList>
+                    <PhoneNumber>
+                      <Notes>Lead School Secretary (Mobile)</Notes>
+                      <Type>MOB</Type>
+                      <Number>(021) 300 999</Number>
+                    </PhoneNumber>
+                  </PhoneNumberList>
+                  <Type>998</Type>
+                  <OrganisationRefId>922</OrganisationRefId>
+                  <OrganisationLocalId>99204</OrganisationLocalId>
+                </Organisation>
+              </Organisations>
+      responses:
+        "200":
+          description: Create successful; returns created objects
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  Organisations:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/Organisations
+              example:
+                $ref: "#/paths/~1organisation/post/requestBody/content/application~\
+                  1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  Organisations:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/Organisations
+              example:
+                $ref: "#/paths/~1organisation/post/requestBody/content/application~\
+                  1xml/example"
+        "401":
+          $ref: "#/paths/~1search/get/responses/401"
+        "422":
+          $ref: "#/paths/~1search/get/responses/422"
+        default:
+          description: Some objects created, some creates failed
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  anyOf:
+                    - type: object
+                      title: Error
+                      properties:
+                        Error:
+                          type: object
+                          title: error
+                          required:
+                            - error
+                            - when
+                            - errorstr
+                          additionalProperties: false
+                          properties:
+                            error:
+                              type: integer
+                              description: Edsby defined error code
+                            when:
+                              type: string
+                              format: date-time
+                              description: Date and Time of when the HTTP request was
+                                processed.
+                            errorstr:
+                              type: string
+                              description: Narrative text describing the error
+                            refId:
+                              type: string
+                              description: Data object refId of the object being
+                                created/updated
+                            localId:
+                              type: string
+                              description: Data object localId of the object being
+                                created/updated
+                    - type: object
+                      title: Organisation
+                      properties:
+                        Organisation:
+                          $ref: jsonSchema.NZ.create.yaml#/properties/Organisation
+              example:
+                - Organisation:
+                    OrganisationRefId: "922"
+                    OrganisationLocalId: "42342"
+                    Name: Hogwart's Area School
+                    Authority: STATE
+                    SectorRole: "35003"
+                    Type: "10030"
+                    OperationalStatus: O
+                    EntityOpen: 1652-04-01
+                    EducationRegion: "12013"
+                    SpecialEducationDistrict: "182011"
+                    AddressList:
+                      Address:
+                        - Type: RU
+                          Role: PHY
+                          Line1: 1175 Lake Ferry Rd
+                          Suburb: RD 1
+                          City: Martinborough
+                    CommunicationChannelList:
+                      Channel:
+                        - Notes: Attendance System (Self Service)
+                          Type: WEB
+                          Value: http://att.hogwarts.school.nz
+                        - Notes: School Website
+                          Type: WEB
+                          Value: http://www.hogwarts.school.nz
+                    ContactList:
+                      Contact:
+                        - Name:
+                            FamilyName: Dumbledore
+                            GivenName: Albus
+                            FullName: Albus Dumbledore
+                          PositionTitle: Headmaster
+                          Role: PRI
+                          AddressList:
+                            Address:
+                              - Type: TH
+                                Role: PHY
+                                Line1: 533 Hogwart's Way
+                                City: Hogsmead
+                                PostalCode: "7733"
+                          EmailList:
+                            Email: []
+                          PhoneNumberList:
+                            PhoneNumber: []
+                        - Name:
+                            FamilyName: Hagrid
+                            GivenName: Rubeus
+                            FullName: Rubeus Hagrid
+                          PositionTitle: Gamekeeper
+                          Role: DIR
+                          AddressList:
+                            Address:
+                              - Type: TH
+                                Role: PHY
+                                Line1: The Enchanted Wood
+                                Line2: 533 Hogwart's Way
+                                City: Hogsmead
+                                PostalCode: "7733"
+                          EmailList:
+                            Email: []
+                          PhoneNumberList:
+                            PhoneNumber: []
+                    EmailList:
+                      Email:
+                        - Type: PRIM
+                          Address: stuart@gmail.com
+                    LocationList:
+                      Location:
+                        - Description: Only Campus
+                          Address:
+                            Type: RU
+                            Role: PHY
+                            Line1: 1175 Lake Ferry Rd
+                            Suburb: RD 1
+                            City: Martinborough
+                            PostalCode: "5781"
+                          GridLocation:
+                            Latitude: -41.2814719
+                            Longitude: 175.3458472
+                          StatisticalAreaList:
+                            StatisticalArea:
+                              - SpatialUnitType: GE
+                                Code: "058"
+                              - SpatialUnitType: TA
+                                Code: "050"
+                              - SpatialUnitType: WA
+                                Code: "05003"
+                    PhoneNumberList:
+                      PhoneNumber:
+                        - Notes: Attendance Office (Automated)
+                          Usage: SMS
+                          Type: WTE
+                          Number: (0274) 300 9991
+                        - Notes: Attendance Office
+                          Usage: INT
+                          Type: WTE
+                          Number: (04) 300 9992
+                        - Notes: School Secretary DDI
+                          Type: WTE
+                          Number: (04) 300 9993
+                    SchoolService:
+                      CoEdStatus: COED
+                      Decile: 5
+                      NewEntrantPolicyList:
+                        EnactedPolicy:
+                          - EffectiveTo: 2018-12-31
+                            Policy: AE
+                          - EffectiveFrom: 2019-01-01
+                            Policy: CE
+                      SchoolYearList:
+                        SchoolYear:
+                          - YearLevel: 1
+                            FIRSTSchoolYearGenderId: 1001
+                            Gender: C
+                          - YearLevel: 2
+                            FIRSTSchoolYearGenderId: 1002
+                            Gender: C
+                          - YearLevel: 3
+                            FIRSTSchoolYearGenderId: 1003
+                            Gender: C
+                          - YearLevel: 4
+                            FIRSTSchoolYearGenderId: 1004
+                            Gender: C
+                          - YearLevel: 5
+                            FIRSTSchoolYearGenderId: 1005
+                            Gender: C
+                          - YearLevel: 6
+                            FIRSTSchoolYearGenderId: 1006
+                            Gender: C
+                          - YearLevel: 7
+                            FIRSTSchoolYearGenderId: 1007
+                            Gender: C
+                          - YearLevel: 8
+                            FIRSTSchoolYearGenderId: 1008
+                            Gender: C
+                          - YearLevel: 9
+                            FIRSTSchoolYearGenderId: 1009
+                            Gender: F
+                          - YearLevel: 10
+                            FIRSTSchoolYearGenderId: 1010
+                            Gender: F
+                          - YearLevel: 11
+                            FIRSTSchoolYearGenderId: 1011
+                            Gender: F
+                          - YearLevel: 12
+                            FIRSTSchoolYearGenderId: 1012
+                            Gender: F
+                          - YearLevel: 13
+                            FIRSTSchoolYearGenderId: 1013
+                            Gender: F
+                - Error:
+                    error: 1009
+                    when: 2020-07-16T20:00:46.000Z
+                    errorstr: "Bad field: PersonInfo-Name-FamilyName: missing required
+                      field PersonInfo-Name-FamilyName (LastName) 'None'"
+                    localId: ST-002
+                    refId: null
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  Response:
+                    type: array
+                    items:
+                      anyOf:
+                        - type: object
+                          title: Error
+                          properties:
+                            Error:
+                              type: object
+                              title: error
+                              required:
+                                - error
+                                - when
+                                - errorstr
+                              additionalProperties: false
+                              properties:
+                                error:
+                                  type: integer
+                                  description: Edsby defined error code
+                                when:
+                                  type: string
+                                  format: date-time
+                                  description: Date and Time of when the HTTP request was
+                                    processed.
+                                errorstr:
+                                  type: string
+                                  description: Narrative text describing the error
+                                refId:
+                                  type: string
+                                  description: Data object refId of the object being
+                                    created/updated
+                                localId:
+                                  type: string
+                                  description: Data object localId of the object being
+                                    created/updated
+                        - type: object
+                          title: Organisation
+                          properties:
+                            Organisation:
+                              $ref: jsonSchema.NZ.create.yaml#/properties/Organisation
+              example: >-
+                <Response>
+                  <Organisation>
+                    <AddressList/>
+                    <CommunicationChannelList/>
+                    <ContactList>
+                      <Contact>
+                        <Name>
+                          <FamilyName>Dumbledore</FamilyName>
+                          <GivenName>Albus</GivenName>
+                          <FullName>Albus Dumbledore</FullName>
+                        </Name>
+                        <PositionTitle>Lead School Headmaster</PositionTitle>
+                        <Role>PRI</Role>
+                        <AddressList>
+                          <Address>
+                            <Type>TH</Type>
+                            <Role>PHY</Role>
+                            <Line1>533 Hogwart's Way</Line1>
+                            <City>Hogsmead</City>
+                            <PostalCode>7733</PostalCode>
+                          </Address>
+                        </AddressList>
+                        <EmailList/>
+                        <PhoneNumberList/>
+                      </Contact>
+                    </ContactList>
+                    <EmailList>
+                      <Email>
+                        <Type>PRIM</Type>
+                        <Address>hogwarts@mailinator.com</Address>
+                      </Email>
+                    </EmailList>
+                    <LocationList/>
+                    <Name>Masterton (Whakaoriori) Kāhui Ako</Name>
+                    <PhoneNumberList>
+                      <PhoneNumber>
+                        <Notes>Lead School Secretary (Mobile)</Notes>
+                        <Type>MOB</Type>
+                        <Number>(021) 300 999</Number>
+                      </PhoneNumber>
+                    </PhoneNumberList>
+                    <Type>998</Type>
+                    <OrganisationRefId>922</OrganisationRefId>
+                    <OrganisationLocalId>99204</OrganisationLocalId>
+                  </Organisation>    
+                  <Error>
+                    <error>1009</error>
+                    <when>2020-07-16T20:00:46.000Z</when>
+                    <errorstr>Bad field: PersonInfo-Name-FamilyName: missing required field PersonInfo-Name-FamilyName (LastName) 'None'</errorstr>
+                    <localId>ST-002</localId>
+                    <refId/>
+                  </Error>      
+                </Response>
+    get:
+      tags:
+        - Organisation
+        - OrganisationBulk
+      summary: Retrieve one or more Organisations
+      description: Bulk operation to retrieve all available Organisations, each of which
+        represents a single recognised Education Provider entity (ECEs, Schools
+        & Tertiary  Education Institutions), Community (Kāhui Ako, Learning
+        Support Clusters, etc.), or others unit(Teen Parent Units, Activity
+        Centres. etc.)
+      operationId: getOrganisations
+      parameters:
+        - name: fields
+          in: query
+          description: Return only specified fields	`fields=name,nid`
+          required: false
+          schema:
+            type: string
+          example: PersonInfo.Name.FamilyName,PersonInfo.Name.GivenName
+        - $ref: "#/paths/~1search/get/parameters/4"
+        - $ref: "#/paths/~1search/get/parameters/3"
+        - name: unwrap
+          in: query
+          description: Remove top level wrapper from json results in single result
+            reponses;	`unwrap=1`
+          required: false
+          schema:
+            enum:
+              - 0
+              - 1
+              - 2
+          example: 1
+        - $ref: "#/paths/~1search/get/parameters/5"
+        - name: sort
+          in: query
+          description: Sort results by specified field;	`sort=FamilyName`
+          required: false
+          schema:
+            type: string
+          example: PersonInfo.Name.FamilyName,PersonInfo.Name.GivenName
+        - name: field
+          in: query
+          description: Field to filter on when used with **pattern**;	`field=FamilyName`
+          required: false
+          schema:
+            type: string
+          example: PersonName.Name.FamilyName
+        - name: pattern
+          in: query
+          description: Filter results using pattern on **field**; `pattern=We*`
+          required: false
+          schema:
+            type: string
+          example: We*
+        - $ref: "#/paths/~1search/get/parameters/6"
+      security:
+        - sifDataObject:
+            - SMS
+            - FIRST
+            - SUPS
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  Organisations:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/Organisations
+              example:
+                $ref: "#/paths/~1organisation/post/requestBody/content/application~\
+                  1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  Organisations:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/Organisations
+              example:
+                $ref: "#/paths/~1organisation/post/requestBody/content/application~\
+                  1xml/example"
+        "401":
+          $ref: "#/paths/~1search/get/responses/401"
+        "422":
+          $ref: "#/paths/~1search/get/responses/422"
+        default:
+          description: Failed to retrieve object(s).
+          content:
+            application/json:
+              schema:
+                type: object
+                title: error
+                required:
+                  - error
+                  - when
+                  - errorstr
+                additionalProperties: false
+                properties:
+                  error:
+                    type: integer
+                    description: Edsby defined error code
+                  when:
+                    type: string
+                    format: date-time
+                    description: Date and Time of when the HTTP request was processed.
+                  errorstr:
+                    type: string
+                    description: Narrative text describing the error
+                  refId:
+                    type: string
+                    description: Data object refId of the object being created/updated
+                  localId:
+                    type: string
+                    description: Data object localId of the object being created/updated
+              example:
+                error: 1009
+                when: 2020-07-16T20:00:46.000Z
+                errorstr: "Bad field: PersonInfo-Name-FamilyName: missing required field
+                  PersonInfo-Name-FamilyName (LastName) 'None'"
+                localId: ST-002
+            application/xml:
+              schema:
+                type: object
+                title: error
+                required:
+                  - error
+                  - when
+                  - errorstr
+                additionalProperties: false
+                properties:
+                  error:
+                    type: integer
+                    description: Edsby defined error code
+                  when:
+                    type: string
+                    format: date-time
+                    description: Date and Time of when the HTTP request was processed.
+                  errorstr:
+                    type: string
+                    description: Narrative text describing the error
+                  refId:
+                    type: string
+                    description: Data object refId of the object being created/updated
+                  localId:
+                    type: string
+                    description: Data object localId of the object being created/updated
+              example: >-
+                <Error>
+                  <error>1009</error>
+                  <when>2020-07-16T20:00:46.000Z</when>
+                  <errorstr>Bad field: PersonInfo-Name-FamilyName: missing required field PersonInfo-Name-FamilyName (LastName) 'None'</errorstr>
+                  <localId>ST-002</localId>
+                </Error>
+    put:
+      tags:
+        - Organisation
+        - OrganisationBulk
+      summary: Update one or more Organisations
+      description: "Bulk operation to update one or more Organisations, each of which
+        represents a single recognised Education Provider entity (ECEs, Schools
+        & Tertiary  Education Institutions), Community (Kāhui Ako, Learning
+        Support Clusters, etc.), or others unit(Teen Parent Units, Activity
+        Centres. etc.)    "
+      operationId: updateOrganisations
+      security:
+        - sifDataObject:
+            - FIRST
+      parameters:
+        - $ref: "#/paths/~1search/get/parameters/6"
+      requestBody:
+        description: CRUD operation on Organisation
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                Organisations:
+                  $ref: jsonSchema.NZ.create.yaml#/properties/Organisations
+            example:
+              $ref: "#/paths/~1organisation/post/requestBody/content/application~1j\
+                son/example"
+          application/xml:
+            schema:
+              type: object
+              properties:
+                Organisations:
+                  $ref: jsonSchema.NZ.create.yaml#/properties/Organisations
+            example:
+              $ref: "#/paths/~1organisation/post/requestBody/content/application~1x\
+                ml/example"
+      responses:
+        "200":
+          description: Update successful; returns updated objects
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  Organisations:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/Organisations
+              example:
+                $ref: "#/paths/~1organisation/post/requestBody/content/application~\
+                  1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  Organisations:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/Organisations
+              example:
+                $ref: "#/paths/~1organisation/post/requestBody/content/application~\
+                  1xml/example"
+        "401":
+          $ref: "#/paths/~1search/get/responses/401"
+        "422":
+          $ref: "#/paths/~1search/get/responses/422"
+        default:
+          description: Some objects updated, some updates failed
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  anyOf:
+                    - type: object
+                      title: Error
+                      properties:
+                        Error:
+                          $ref: "#/paths/~1organisation/post/responses/default/cont\
+                            ent/application~1json/schema/items/anyOf/0/properti\
+                            es/Error"
+                    - type: object
+                      title: Organisation
+                      properties:
+                        Organisation:
+                          $ref: jsonSchema.NZ.create.yaml#/properties/Organisation
+              example:
+                $ref: "#/paths/~1organisation/post/responses/default/content/applic\
+                  ation~1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  Response:
+                    type: array
+                    items:
+                      anyOf:
+                        - type: object
+                          title: Error
+                          properties:
+                            Error:
+                              $ref: "#/paths/~1organisation/post/responses/default/\
+                                content/application~1xml/schema/properties/Resp\
+                                onse/items/anyOf/0/properties/Error"
+                        - type: object
+                          title: Organisation
+                          properties:
+                            Organisation:
+                              $ref: jsonSchema.NZ.create.yaml#/properties/Organisation
+              example:
+                $ref: "#/paths/~1organisation/post/responses/default/content/applic\
+                  ation~1xml/example"
+    patch:
+      tags:
+        - Organisation
+        - OrganisationBulk
+      summary: Patch one or more Organisations
+      description: Bulk operation to update one or more fields of one or more
+        Organisations, each of which represents a single recognised Education
+        Provider entity (ECEs, Schools & Tertiary  Education Institutions),
+        Community (Kāhui Ako, Learning Support Clusters, etc.), or others
+        unit(Teen Parent Units, Activity Centres. etc.)
+      operationId: patchOrganisations
+      security:
+        - sifDataObject:
+            - FIRST
+      parameters:
+        - $ref: "#/paths/~1search/get/parameters/6"
+      requestBody:
+        description: CRUD operation on Organisation
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                Organisations:
+                  $ref: jsonSchema.NZ.update.yaml#/properties/Organisations
+            example:
+              $ref: "#/paths/~1organisation/post/requestBody/content/application~1j\
+                son/example"
+          application/xml:
+            schema:
+              type: object
+              properties:
+                Organisations:
+                  $ref: jsonSchema.NZ.update.yaml#/properties/Organisations
+            example:
+              $ref: "#/paths/~1organisation/post/requestBody/content/application~1x\
+                ml/example"
+      responses:
+        "200":
+          description: Patch successful; returns patched objects
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  Organisations:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/Organisations
+              example:
+                $ref: "#/paths/~1organisation/post/requestBody/content/application~\
+                  1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  Organisations:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/Organisations
+              example:
+                $ref: "#/paths/~1organisation/post/requestBody/content/application~\
+                  1xml/example"
+        "401":
+          $ref: "#/paths/~1search/get/responses/401"
+        "422":
+          $ref: "#/paths/~1search/get/responses/422"
+        default:
+          description: Some objects patched, some patches failed
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  anyOf:
+                    - type: object
+                      title: Error
+                      properties:
+                        Error:
+                          $ref: "#/paths/~1organisation/post/responses/default/cont\
+                            ent/application~1json/schema/items/anyOf/0/properti\
+                            es/Error"
+                    - type: object
+                      title: Organisation
+                      properties:
+                        Organisation:
+                          $ref: jsonSchema.NZ.create.yaml#/properties/Organisation
+              example:
+                $ref: "#/paths/~1organisation/post/responses/default/content/applic\
+                  ation~1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  Response:
+                    type: array
+                    items:
+                      anyOf:
+                        - type: object
+                          title: Error
+                          properties:
+                            Error:
+                              $ref: "#/paths/~1organisation/post/responses/default/\
+                                content/application~1xml/schema/properties/Resp\
+                                onse/items/anyOf/0/properties/Error"
+                        - type: object
+                          title: Organisation
+                          properties:
+                            Organisation:
+                              $ref: jsonSchema.NZ.create.yaml#/properties/Organisation
+              example:
+                $ref: "#/paths/~1organisation/post/responses/default/content/applic\
+                  ation~1xml/example"
+  "/organisation/{OrganisationRefId}":
+    get:
+      tags:
+        - Organisation
+        - OrganisationSingle
+      summary: Retrieve a single Organisation
+      description: "Retrive a particular Organisation, which represents a single recognised
+        Education Provider entity (ECEs, Schools & Tertiary  Education
+        Institutions), Community (Kāhui Ako, Learning Support Clusters, etc.),
+        or others unit(Teen Parent Units, Activity Centres. etc.)    "
+      operationId: getOrganisation
+      security:
+        - sifDataObject:
+            - SMS
+            - FIRST
+            - SUPS
+      parameters:
+        - $ref: "#/paths/~1organisation/get/parameters/0"
+        - $ref: "#/paths/~1search/get/parameters/4"
+        - $ref: "#/paths/~1search/get/parameters/3"
+        - $ref: "#/paths/~1organisation/get/parameters/3"
+        - $ref: "#/paths/~1search/get/parameters/5"
+        - $ref: "#/paths/~1organisation/get/parameters/5"
+        - $ref: "#/paths/~1organisation/get/parameters/6"
+        - $ref: "#/paths/~1organisation/get/parameters/7"
+        - $ref: "#/paths/~1search/get/parameters/6"
+        - name: OrganisationRefId
+          in: path
+          required: true
+          description: <p>The Ministry of Education Organisation Id of the Provider(or
+            other Organisation); being worked on.</p>
+          schema:
+            type: string
+            pattern: ^[1-9][0-9]{0,4}$
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  Organisation:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/Organisation
+              example:
+                Organisation:
+                  OrganisationRefId: "922"
+                  OrganisationLocalId: "42342"
+                  Name: Hogwart's Area School
+                  Authority: STATE
+                  SectorRole: "35003"
+                  Type: "10030"
+                  OperationalStatus: O
+                  EntityOpen: 1652-04-01
+                  EducationRegion: "12013"
+                  SpecialEducationDistrict: "182011"
+                  AddressList:
+                    Address:
+                      - Type: RU
+                        Role: PHY
+                        Line1: 1175 Lake Ferry Rd
+                        Suburb: RD 1
+                        City: Martinborough
+                  CommunicationChannelList:
+                    Channel:
+                      - Notes: Attendance System (Self Service)
+                        Type: WEB
+                        Value: http://att.hogwarts.school.nz
+                      - Notes: School Website
+                        Type: WEB
+                        Value: http://www.hogwarts.school.nz
+                  ContactList:
+                    Contact:
+                      - Name:
+                          FamilyName: Dumbledore
+                          GivenName: Albus
+                          FullName: Albus Dumbledore
+                        PositionTitle: Headmaster
+                        Role: PRI
+                        AddressList:
+                          Address:
+                            - Type: TH
+                              Role: PHY
+                              Line1: 533 Hogwart's Way
+                              City: Hogsmead
+                              PostalCode: "7733"
+                        EmailList:
+                          Email: []
+                        PhoneNumberList:
+                          PhoneNumber: []
+                      - Name:
+                          FamilyName: Hagrid
+                          GivenName: Rubeus
+                          FullName: Rubeus Hagrid
+                        PositionTitle: Gamekeeper
+                        Role: DIR
+                        AddressList:
+                          Address:
+                            - Type: TH
+                              Role: PHY
+                              Line1: The Enchanted Wood
+                              Line2: 533 Hogwart's Way
+                              City: Hogsmead
+                              PostalCode: "7733"
+                        EmailList:
+                          Email: []
+                        PhoneNumberList:
+                          PhoneNumber: []
+                  EmailList:
+                    Email:
+                      - Type: PRIM
+                        Address: stuart@gmail.com
+                  LocationList:
+                    Location:
+                      - Description: Only Campus
+                        Address:
+                          Type: RU
+                          Role: PHY
+                          Line1: 1175 Lake Ferry Rd
+                          Suburb: RD 1
+                          City: Martinborough
+                          PostalCode: "5781"
+                        GridLocation:
+                          Latitude: -41.2814719
+                          Longitude: 175.3458472
+                        StatisticalAreaList:
+                          StatisticalArea:
+                            - SpatialUnitType: GE
+                              Code: "058"
+                            - SpatialUnitType: TA
+                              Code: "050"
+                            - SpatialUnitType: WA
+                              Code: "05003"
+                  PhoneNumberList:
+                    PhoneNumber:
+                      - Notes: Attendance Office (Automated)
+                        Usage: SMS
+                        Type: WTE
+                        Number: (0274) 300 9991
+                      - Notes: Attendance Office
+                        Usage: INT
+                        Type: WTE
+                        Number: (04) 300 9992
+                      - Notes: School Secretary DDI
+                        Type: WTE
+                        Number: (04) 300 9993
+                  SchoolService:
+                    CoEdStatus: COED
+                    Decile: 5
+                    NewEntrantPolicyList:
+                      EnactedPolicy:
+                        - EffectiveTo: 2018-12-31
+                          Policy: AE
+                        - EffectiveFrom: 2019-01-01
+                          Policy: CE
+                    SchoolYearList:
+                      SchoolYear:
+                        - YearLevel: 1
+                          FIRSTSchoolYearGenderId: 1001
+                          Gender: C
+                        - YearLevel: 2
+                          FIRSTSchoolYearGenderId: 1002
+                          Gender: C
+                        - YearLevel: 3
+                          FIRSTSchoolYearGenderId: 1003
+                          Gender: C
+                        - YearLevel: 4
+                          FIRSTSchoolYearGenderId: 1004
+                          Gender: C
+                        - YearLevel: 5
+                          FIRSTSchoolYearGenderId: 1005
+                          Gender: C
+                        - YearLevel: 6
+                          FIRSTSchoolYearGenderId: 1006
+                          Gender: C
+                        - YearLevel: 7
+                          FIRSTSchoolYearGenderId: 1007
+                          Gender: C
+                        - YearLevel: 8
+                          FIRSTSchoolYearGenderId: 1008
+                          Gender: C
+                        - YearLevel: 9
+                          FIRSTSchoolYearGenderId: 1009
+                          Gender: F
+                        - YearLevel: 10
+                          FIRSTSchoolYearGenderId: 1010
+                          Gender: F
+                        - YearLevel: 11
+                          FIRSTSchoolYearGenderId: 1011
+                          Gender: F
+                        - YearLevel: 12
+                          FIRSTSchoolYearGenderId: 1012
+                          Gender: F
+                        - YearLevel: 13
+                          FIRSTSchoolYearGenderId: 1013
+                          Gender: F
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  Organisation:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/Organisation
+              example: |-
+                <Organisation>
+                  <AddressList/>
+                  <CommunicationChannelList/>
+                  <ContactList>
+                    <Contact>
+                      <Name>
+                        <FamilyName>Dumbledore</FamilyName>
+                        <GivenName>Albus</GivenName>
+                        <FullName>Albus Dumbledore</FullName>
+                      </Name>
+                      <PositionTitle>Lead School Headmaster</PositionTitle>
+                      <Role>PRI</Role>
+                      <AddressList>
+                        <Address>
+                          <Type>TH</Type>
+                          <Role>PHY</Role>
+                          <Line1>533 Hogwart's Way</Line1>
+                          <City>Hogsmead</City>
+                          <PostalCode>7733</PostalCode>
+                        </Address>
+                      </AddressList>
+                      <EmailList/>
+                      <PhoneNumberList/>
+                    </Contact>
+                  </ContactList>
+                  <EmailList>
+                    <Email>
+                      <Type>PRIM</Type>
+                      <Address>hogwarts@mailinator.com</Address>
+                    </Email>
+                  </EmailList>
+                  <LocationList/>
+                  <Name>Masterton (Whakaoriori) Kāhui Ako</Name>
+                  <PhoneNumberList>
+                    <PhoneNumber>
+                      <Notes>Lead School Secretary (Mobile)</Notes>
+                      <Type>MOB</Type>
+                      <Number>(021) 300 999</Number>
+                    </PhoneNumber>
+                  </PhoneNumberList>
+                  <Type>998</Type>
+                  <OrganisationRefId>922</OrganisationRefId>
+                  <OrganisationLocalId>99204</OrganisationLocalId>
+                </Organisation>
+        "401":
+          $ref: "#/paths/~1search/get/responses/401"
+        "422":
+          $ref: "#/paths/~1search/get/responses/422"
+        default:
+          $ref: "#/paths/~1organisation/get/responses/default"
+    put:
+      tags:
+        - Organisation
+        - OrganisationSingle
+      summary: Update a single Organisation
+      description: "Update a particular Organisation, which represents a single recognised
+        Education Provider entity (ECEs, Schools & Tertiary  Education
+        Institutions), Community (Kāhui Ako, Learning Support Clusters, etc.),
+        or others unit(Teen Parent Units, Activity Centres. etc.)    "
+      operationId: updateOrganisation
+      security:
+        - sifDataObject:
+            - FIRST
+      parameters:
+        - $ref: "#/paths/~1search/get/parameters/6"
+        - name: OrganisationRefId
+          in: path
+          required: true
+          description: <p>The Ministry of Education Organisation Id of the Provider(or
+            other Organisation); being worked on.</p>
+          schema:
+            type: string
+            pattern: ^[1-9][0-9]{0,4}$
+      requestBody:
+        description: CRUD operation on Organisation
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                Organisation:
+                  $ref: jsonSchema.NZ.create.yaml#/properties/Organisation
+            example:
+              $ref: "#/paths/~1organisation~1%7BOrganisationRefId%7D/get/responses/\
+                200/content/application~1json/example"
+          application/xml:
+            schema:
+              type: object
+              properties:
+                Organisation:
+                  $ref: jsonSchema.NZ.create.yaml#/properties/Organisation
+            example:
+              $ref: "#/paths/~1organisation~1%7BOrganisationRefId%7D/get/responses/\
+                200/content/application~1xml/example"
+      responses:
+        "200":
+          description: Update successful; returns updated object
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  Organisation:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/Organisation
+              example:
+                $ref: "#/paths/~1organisation~1%7BOrganisationRefId%7D/get/response\
+                  s/200/content/application~1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  Organisation:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/Organisation
+              example:
+                $ref: "#/paths/~1organisation~1%7BOrganisationRefId%7D/get/response\
+                  s/200/content/application~1xml/example"
+        "401":
+          $ref: "#/paths/~1search/get/responses/401"
+        "422":
+          $ref: "#/paths/~1search/get/responses/422"
+        default:
+          description: Failed to update object.
+          content:
+            application/json:
+              schema:
+                type: object
+                title: error
+                required:
+                  - error
+                  - when
+                  - errorstr
+                additionalProperties: false
+                properties:
+                  error:
+                    type: integer
+                    description: Edsby defined error code
+                  when:
+                    type: string
+                    format: date-time
+                    description: Date and Time of when the HTTP request was processed.
+                  errorstr:
+                    type: string
+                    description: Narrative text describing the error
+                  refId:
+                    type: string
+                    description: Data object refId of the object being created/updated
+                  localId:
+                    type: string
+                    description: Data object localId of the object being created/updated
+              example:
+                error: 1009
+                when: 2020-07-16T20:00:46.000Z
+                errorstr: "Bad field: PersonInfo-Name-FamilyName: missing required field
+                  PersonInfo-Name-FamilyName (LastName) 'None'"
+                localId: ST-002
+            application/xml:
+              schema:
+                type: object
+                title: error
+                required:
+                  - error
+                  - when
+                  - errorstr
+                additionalProperties: false
+                properties:
+                  error:
+                    type: integer
+                    description: Edsby defined error code
+                  when:
+                    type: string
+                    format: date-time
+                    description: Date and Time of when the HTTP request was processed.
+                  errorstr:
+                    type: string
+                    description: Narrative text describing the error
+                  refId:
+                    type: string
+                    description: Data object refId of the object being created/updated
+                  localId:
+                    type: string
+                    description: Data object localId of the object being created/updated
+              example: >-
+                <Error>
+                  <error>1009</error>
+                  <when>2020-07-16T20:00:46.000Z</when>
+                  <errorstr>Bad field: PersonInfo-Name-FamilyName: missing required field PersonInfo-Name-FamilyName (LastName) 'None'</errorstr>
+                  <localId>ST-002</localId>
+                </Error>
+    patch:
+      tags:
+        - Organisation
+        - OrganisationSingle
+      summary: Patch a single Organisation
+      description: Update one or more fields of a particular Organisation, which represents
+        a single recognised Education Provider entity (ECEs, Schools &
+        Tertiary  Education Institutions), Community (Kāhui Ako, Learning
+        Support Clusters, etc.), or others unit(Teen Parent Units, Activity
+        Centres. etc.)
+      operationId: patchOrganisation
+      security:
+        - sifDataObject:
+            - FIRST
+      parameters:
+        - $ref: "#/paths/~1search/get/parameters/6"
+        - name: OrganisationRefId
+          in: path
+          required: true
+          description: <p>The Ministry of Education Organisation Id of the Provider(or
+            other Organisation); being worked on.</p>
+          schema:
+            type: string
+            pattern: ^[1-9][0-9]{0,4}$
+      requestBody:
+        description: CRUD operation on Organisation
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                Organisation:
+                  $ref: jsonSchema.NZ.update.yaml#/properties/Organisation
+            example:
+              $ref: "#/paths/~1organisation~1%7BOrganisationRefId%7D/get/responses/\
+                200/content/application~1json/example"
+          application/xml:
+            schema:
+              type: object
+              properties:
+                Organisation:
+                  $ref: jsonSchema.NZ.update.yaml#/properties/Organisation
+            example:
+              $ref: "#/paths/~1organisation~1%7BOrganisationRefId%7D/get/responses/\
+                200/content/application~1xml/example"
+      responses:
+        "200":
+          description: Patch successful; returns patched object
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  Organisation:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/Organisation
+              example:
+                $ref: "#/paths/~1organisation~1%7BOrganisationRefId%7D/get/response\
+                  s/200/content/application~1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  Organisation:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/Organisation
+              example:
+                $ref: "#/paths/~1organisation~1%7BOrganisationRefId%7D/get/response\
+                  s/200/content/application~1xml/example"
+        "401":
+          $ref: "#/paths/~1search/get/responses/401"
+        "422":
+          $ref: "#/paths/~1search/get/responses/422"
+        default:
+          description: Failed to patch object.
+          content:
+            application/json:
+              schema:
+                type: object
+                title: error
+                required:
+                  - error
+                  - when
+                  - errorstr
+                additionalProperties: false
+                properties:
+                  error:
+                    type: integer
+                    description: Edsby defined error code
+                  when:
+                    type: string
+                    format: date-time
+                    description: Date and Time of when the HTTP request was processed.
+                  errorstr:
+                    type: string
+                    description: Narrative text describing the error
+                  refId:
+                    type: string
+                    description: Data object refId of the object being created/updated
+                  localId:
+                    type: string
+                    description: Data object localId of the object being created/updated
+              example:
+                error: 1009
+                when: 2020-07-16T20:00:46.000Z
+                errorstr: "Bad field: PersonInfo-Name-FamilyName: missing required field
+                  PersonInfo-Name-FamilyName (LastName) 'None'"
+                localId: ST-002
+            application/xml:
+              schema:
+                type: object
+                title: error
+                required:
+                  - error
+                  - when
+                  - errorstr
+                additionalProperties: false
+                properties:
+                  error:
+                    type: integer
+                    description: Edsby defined error code
+                  when:
+                    type: string
+                    format: date-time
+                    description: Date and Time of when the HTTP request was processed.
+                  errorstr:
+                    type: string
+                    description: Narrative text describing the error
+                  refId:
+                    type: string
+                    description: Data object refId of the object being created/updated
+                  localId:
+                    type: string
+                    description: Data object localId of the object being created/updated
+              example: >-
+                <Error>
+                  <error>1009</error>
+                  <when>2020-07-16T20:00:46.000Z</when>
+                  <errorstr>Bad field: PersonInfo-Name-FamilyName: missing required field PersonInfo-Name-FamilyName (LastName) 'None'</errorstr>
+                  <localId>ST-002</localId>
+                </Error>
+  "/organisation/{OrganisationRefId}/organisationrelationship":
+    post:
+      tags:
+        - OrganisationRelationship
+        - OrganisationRelationshipBulk
+      summary: Create one or more OrganisationRelationships
+      description: Bulk operation to create one or more OrganisationRelationships, each of
+        which represents  a single recognised relationship between two education
+        Organisations. The two organisations are referred to as the Source
+        Organisation and the Related Organisation.</p> <p>RelationshipType
+        records the nature of the relationship between the two
+        organisations,  and gives guidance on which is the Source Organisation
+        and which is the Related Organisation.</p>
+      operationId: createOrganisationRelationships
+      security:
+        - sifDataObject:
+            - FIRST
+      parameters:
+        - $ref: "#/paths/~1organisation/post/parameters/0"
+        - $ref: "#/paths/~1search/get/parameters/6"
+        - name: OrganisationRefId
+          in: path
+          required: true
+          description: <p>The Ministry of Education Organisation Id of the Provider (or
+            other Organisation) that must be either the <strong>source</strong>
+            or <strong>related</strong> Organisation of the organisation
+            relationships.
+          schema:
+            type: string
+            pattern: ^[1-9][0-9]{0,4}$
+          example: "9651"
+      requestBody:
+        description: CRUD operation on OrganisationRelationship
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                OrganisationRelationships:
+                  $ref: jsonSchema.NZ.create.yaml#/properties/OrganisationRelationships
+            example:
+              OrganisationRelationships:
+                OrganisationRelationship:
+                  - OrganisationRelationshipLocalId: 90100_8001
+                    Status: A
+                    RelationshipType: "34037"
+                    SourceOrganisation:
+                      RefId: "90100"
+                    SourceOrganisationRole: LSC
+                    SourceOrganisationAgreementDate: 2020-01-15
+                    RelatedOrganisation:
+                      RefId: "8001"
+                    RelatedOrganisationRole: "184000"
+                    RelatedOrganisationAgreementDate: 2020-01-15
+                    EffectiveDate: 2020-01-15
+          application/xml:
+            schema:
+              type: object
+              properties:
+                OrganisationRelationships:
+                  $ref: jsonSchema.NZ.create.yaml#/properties/OrganisationRelationships
+            example: >-
+              <OrganisationRelationships>
+                <OrganisationRelationship>
+                  <OrganisationRelationshipLocalId>90100_8001</OrganisationRelationshipLocalId>
+                  <Status>A</Status>
+                  <RelationshipType>34037</RelationshipType>
+                  <SourceOrganisation>
+                    <RefId>90100</RefId>
+                  </SourceOrganisation>
+                  <SourceOrganisationRole>LSC</SourceOrganisationRole>
+                  <SourceOrganisationAgreementDate>2020-01-15</SourceOrganisationAgreementDate>
+                  <RelatedOrganisation>
+                    <RefId>8001</RefId>
+                  </RelatedOrganisation>
+                  <RelatedOrganisationRole>184000</RelatedOrganisationRole>
+                  <RelatedOrganisationAgreementDate>2020-01-15</RelatedOrganisationAggreementDate>
+                  <EffectiveDate>2020-01-15</EffectiveDate>
+                </OrganisationRelationship>
+                <OrganisationRelationship>
+                  <OrganisationRelationshipLocalId>90100_8002</OrganisationRelationshipLocalId>
+                  <Status>A</Status>
+                  <RelationshipType>34037</RelationshipType>
+                  <SourceOrganisation>
+                    <RefId>90100</RefId>
+                  </SourceOrganisation>
+                  <SourceOrganisationRole>LSC</SourceOrganisationRole>
+                  <SourceOrganisationAgreementDate>2020-01-15</SourceOrganisationAgreementDate>
+                  <RelatedOrganisation>
+                    <RefId>8002</RefId>
+                  </RelatedOrganisation>
+                  <RelatedOrganisationRole>184000</RelatedOrganisationRole>
+                  <RelatedOrganisationAgreementDate>2020-01-16</RelatedOrganisationAggreementDate>
+                  <EffectiveDate>2020-01-16</EffectiveDate>
+                </OrganisationRelationship>
+              </OrganisationRelationships>
+      responses:
+        "200":
+          description: Create successful; returns created objects
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  OrganisationRelationships:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/OrganisationRelationships
+              example:
+                $ref: "#/paths/~1organisation~1%7BOrganisationRefId%7D~1organisatio\
+                  nrelationship/post/requestBody/content/application~1json/exam\
+                  ple"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  OrganisationRelationships:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/OrganisationRelationships
+              example:
+                $ref: "#/paths/~1organisation~1%7BOrganisationRefId%7D~1organisatio\
+                  nrelationship/post/requestBody/content/application~1xml/examp\
+                  le"
+        "401":
+          $ref: "#/paths/~1search/get/responses/401"
+        "422":
+          $ref: "#/paths/~1search/get/responses/422"
+        default:
+          description: Some objects created, some creates failed
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  anyOf:
+                    - type: object
+                      title: Error
+                      properties:
+                        Error:
+                          $ref: "#/paths/~1organisation/post/responses/default/cont\
+                            ent/application~1json/schema/items/anyOf/0/properti\
+                            es/Error"
+                    - type: object
+                      title: OrganisationRelationship
+                      properties:
+                        OrganisationRelationship:
+                          $ref: jsonSchema.NZ.create.yaml#/properties/OrganisationRelationship
+              example:
+                - OrganisationRelationship:
+                    OrganisationRelationshipLocalId: 90100_8001
+                    Status: A
+                    RelationshipType: "34037"
+                    SourceOrganisation:
+                      RefId: "90100"
+                    SourceOrganisationRole: LSC
+                    SourceOrganisationAgreementDate: 2020-01-15
+                    RelatedOrganisation:
+                      RefId: "8001"
+                    RelatedOrganisationRole: "184000"
+                    RelatedOrganisationAgreementDate: 2020-01-15
+                    EffectiveDate: 2020-01-15
+                - Error:
+                    error: 1009
+                    when: 2020-07-16T20:00:46.000Z
+                    errorstr: "Bad field: PersonInfo-Name-FamilyName: missing required
+                      field PersonInfo-Name-FamilyName (LastName) 'None'"
+                    localId: ST-002
+                    refId: null
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  Response:
+                    type: array
+                    items:
+                      anyOf:
+                        - type: object
+                          title: Error
+                          properties:
+                            Error:
+                              $ref: "#/paths/~1organisation/post/responses/default/\
+                                content/application~1xml/schema/properties/Resp\
+                                onse/items/anyOf/0/properties/Error"
+                        - type: object
+                          title: OrganisationRelationship
+                          properties:
+                            OrganisationRelationship:
+                              $ref: jsonSchema.NZ.create.yaml#/properties/OrganisationRelationship
+              example: >-
+                <Response>
+                  <OrganisationRelationship>
+                    <OrganisationRelationshipLocalId>90100_8001</OrganisationRelationshipLocalId>
+                    <Status>A</Status>
+                    <RelationshipType>34037</RelationshipType>
+                    <SourceOrganisation>
+                      <RefId>90100</RefId>
+                    </SourceOrganisation>
+                    <SourceOrganisationRole>LSC</SourceOrganisationRole>
+                    <SourceOrganisationAgreementDate>2020-01-15</SourceOrganisationAgreementDate>
+                    <RelatedOrganisation>
+                      <RefId>8001</RefId>
+                    </RelatedOrganisation>
+                    <RelatedOrganisationRole>184000</RelatedOrganisationRole>
+                    <RelatedOrganisationAgreementDate>2020-01-15</RelatedOrganisationAggreementDate>
+                    <EffectiveDate>2020-01-15</EffectiveDate>
+                  </OrganisationRelationship>
+                  <Error>
+                    <error>1009</error>
+                    <when>2020-07-16T20:00:46.000Z</when>
+                    <errorstr>Bad field: PersonInfo-Name-FamilyName: missing required field PersonInfo-Name-FamilyName (LastName) 'None'</errorstr>
+                    <localId>ST-002</localId>
+                    <refId/>
+                  </Error>      
+                </Response>
+    get:
+      tags:
+        - OrganisationRelationship
+        - OrganisationRelationshipBulk
+      summary: Get a list of OrganisationRelationships
+      description: Bulk operation to retrieve all available OrganisationRelationships where
+        the given OrganisationRelationshipRefId represents either the
+        <strong>Source</strong> or <strong>Related</strong> organisation in the
+        OrganisationRelationship.</p> <p> Each OrganisationRelationship
+        represents a single recognised relationship between two education
+        Organisations. The two organisations are referred to as the
+        Source  Organisation and the Related Organisation.</p>
+        <p>RelationshipType records the nature of the relationship between the
+        two organisations,  and gives guidance on which is the Source
+        Organisation and which is the Related Organisation.</p>
+      operationId: getOrganisationRelationships
+      security:
+        - sifDataObject:
+            - SMS
+            - FIRST
+            - SUPS
+      parameters:
+        - $ref: "#/paths/~1organisation/get/parameters/0"
+        - $ref: "#/paths/~1search/get/parameters/4"
+        - $ref: "#/paths/~1search/get/parameters/3"
+        - $ref: "#/paths/~1organisation/get/parameters/3"
+        - $ref: "#/paths/~1search/get/parameters/5"
+        - name: start
+          in: query
+          description: Include only items from start date;	`start=2017-08-01`
+          required: false
+          schema:
+            type: string
+            format: date
+          example: 2017-08-01
+        - name: end
+          in: query
+          description: Include only items before end date;	`end=2017-08-31`
+          required: false
+          schema:
+            type: string
+            format: date
+          example: 2018-08-31
+        - $ref: "#/paths/~1organisation/get/parameters/5"
+        - $ref: "#/paths/~1organisation/get/parameters/6"
+        - $ref: "#/paths/~1organisation/get/parameters/7"
+        - $ref: "#/paths/~1search/get/parameters/6"
+        - name: OrganisationRefId
+          in: path
+          required: true
+          description: <p>The Ministry of Education Organisation Id of the Provider (or
+            other Organisation) that must be either the <strong>source</strong>
+            or <strong>related</strong> Organisation of the organisation
+            relationships.
+          schema:
+            type: string
+            pattern: ^[1-9][0-9]{0,4}$
+          example: "9651"
+        - name: status
+          in: query
+          description: Filter the results; based upon the value of the Status field
+          required: false
+          schema:
+            type: string
+            oneOf:
+              - enum:
+                  - A
+                title: Active
+                description: Queried object is Active
+              - enum:
+                  - I
+                title: Inactive
+                description: Queried object is
+          example: A
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  OrganisationRelationships:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/OrganisationRelationships
+              example:
+                $ref: "#/paths/~1organisation~1%7BOrganisationRefId%7D~1organisatio\
+                  nrelationship/post/requestBody/content/application~1json/exam\
+                  ple"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  OrganisationRelationships:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/OrganisationRelationships
+              example:
+                $ref: "#/paths/~1organisation~1%7BOrganisationRefId%7D~1organisatio\
+                  nrelationship/post/requestBody/content/application~1xml/examp\
+                  le"
+        "401":
+          $ref: "#/paths/~1search/get/responses/401"
+        "422":
+          $ref: "#/paths/~1search/get/responses/422"
+        default:
+          $ref: "#/paths/~1organisation/get/responses/default"
+    put:
+      tags:
+        - OrganisationRelationship
+        - OrganisationRelationshipBulk
+      summary: Update a list of OrganisationRelationships
+      description: >-
+        Bulk operation to update a set of OrganisationRelationships, each of
+        which represents a  single recognised relationship between two education
+        Organisations. The two organisations
+         are referred to as the Source Organisation and the Related Organisation.</p>
+        <p>RelationshipType records the nature of the relationship between the two organisations,  and gives guidance on which is the Source Organisation and which is the Related Organisation.</p>
+      operationId: updateOrganisationRelationships
+      security:
+        - sifDataObject:
+            - FIRST
+      parameters:
+        - $ref: "#/paths/~1search/get/parameters/6"
+        - name: OrganisationRefId
+          in: path
+          required: true
+          description: <p>The Ministry of Education Organisation Id of the Provider (or
+            other Organisation) that must be either the <strong>source</strong>
+            or <strong>related</strong> Organisation of the organisation
+            relationships.
+          schema:
+            type: string
+            pattern: ^[1-9][0-9]{0,4}$
+          example: "9651"
+      requestBody:
+        description: CRUD operation on OrganisationRelationship
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                OrganisationRelationships:
+                  $ref: jsonSchema.NZ.create.yaml#/properties/OrganisationRelationships
+            example:
+              $ref: "#/paths/~1organisation~1%7BOrganisationRefId%7D~1organisationr\
+                elationship/post/requestBody/content/application~1json/example"
+          application/xml:
+            schema:
+              type: object
+              properties:
+                OrganisationRelationships:
+                  $ref: jsonSchema.NZ.create.yaml#/properties/OrganisationRelationships
+            example:
+              $ref: "#/paths/~1organisation~1%7BOrganisationRefId%7D~1organisationr\
+                elationship/post/requestBody/content/application~1xml/example"
+      responses:
+        "200":
+          description: Update successful; returns updated objects
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  OrganisationRelationships:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/OrganisationRelationships
+              example:
+                $ref: "#/paths/~1organisation~1%7BOrganisationRefId%7D~1organisatio\
+                  nrelationship/post/requestBody/content/application~1json/exam\
+                  ple"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  OrganisationRelationships:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/OrganisationRelationships
+              example:
+                $ref: "#/paths/~1organisation~1%7BOrganisationRefId%7D~1organisatio\
+                  nrelationship/post/requestBody/content/application~1xml/examp\
+                  le"
+        "401":
+          $ref: "#/paths/~1search/get/responses/401"
+        "422":
+          $ref: "#/paths/~1search/get/responses/422"
+        default:
+          description: Some objects updated, some updates failed
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  anyOf:
+                    - type: object
+                      title: Error
+                      properties:
+                        Error:
+                          $ref: "#/paths/~1organisation/post/responses/default/cont\
+                            ent/application~1json/schema/items/anyOf/0/properti\
+                            es/Error"
+                    - type: object
+                      title: OrganisationRelationship
+                      properties:
+                        OrganisationRelationship:
+                          $ref: jsonSchema.NZ.create.yaml#/properties/OrganisationRelationship
+              example:
+                $ref: "#/paths/~1organisation~1%7BOrganisationRefId%7D~1organisatio\
+                  nrelationship/post/responses/default/content/application~1jso\
+                  n/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  Response:
+                    type: array
+                    items:
+                      anyOf:
+                        - type: object
+                          title: Error
+                          properties:
+                            Error:
+                              $ref: "#/paths/~1organisation/post/responses/default/\
+                                content/application~1xml/schema/properties/Resp\
+                                onse/items/anyOf/0/properties/Error"
+                        - type: object
+                          title: OrganisationRelationship
+                          properties:
+                            OrganisationRelationship:
+                              $ref: jsonSchema.NZ.create.yaml#/properties/OrganisationRelationship
+              example:
+                $ref: "#/paths/~1organisation~1%7BOrganisationRefId%7D~1organisatio\
+                  nrelationship/post/responses/default/content/application~1xml\
+                  /example"
+    patch:
+      tags:
+        - OrganisationRelationship
+        - OrganisationRelationshipBulk
+      summary: Patch a list of OrganisationRelationships
+      description: Bulk operation to update one or more fields of a set of
+        OrganisationRelationships, each of which represents a  single recognised
+        relationship between two education Organisations. The two organisations
+        are referred to as the Source Organisation and the Related
+        Organisation.</p> <p>RelationshipType records the nature of the
+        relationship between the two organisations,  and gives guidance on which
+        is the Source Organisation and which is the Related Organisation.</p>
+      operationId: patchOrganisationRelationships
+      security:
+        - sifDataObject:
+            - FIRST
+      parameters:
+        - $ref: "#/paths/~1search/get/parameters/6"
+        - name: OrganisationRefId
+          in: path
+          required: true
+          description: <p>The Ministry of Education Organisation Id of the Provider (or
+            other Organisation) that must be either the <strong>source</strong>
+            or <strong>related</strong> Organisation of the organisation
+            relationships.
+          schema:
+            type: string
+            pattern: ^[1-9][0-9]{0,4}$
+          example: "9651"
+      requestBody:
+        description: CRUD operation on OrganisationRelationship
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                OrganisationRelationships:
+                  $ref: jsonSchema.NZ.update.yaml#/properties/OrganisationRelationships
+            example:
+              $ref: "#/paths/~1organisation~1%7BOrganisationRefId%7D~1organisationr\
+                elationship/post/requestBody/content/application~1json/example"
+          application/xml:
+            schema:
+              type: object
+              properties:
+                OrganisationRelationships:
+                  $ref: jsonSchema.NZ.update.yaml#/properties/OrganisationRelationships
+            example:
+              $ref: "#/paths/~1organisation~1%7BOrganisationRefId%7D~1organisationr\
+                elationship/post/requestBody/content/application~1xml/example"
+      responses:
+        "200":
+          description: Patch successful; returns patched objects
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  OrganisationRelationships:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/OrganisationRelationships
+              example:
+                $ref: "#/paths/~1organisation~1%7BOrganisationRefId%7D~1organisatio\
+                  nrelationship/post/requestBody/content/application~1json/exam\
+                  ple"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  OrganisationRelationships:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/OrganisationRelationships
+              example:
+                $ref: "#/paths/~1organisation~1%7BOrganisationRefId%7D~1organisatio\
+                  nrelationship/post/requestBody/content/application~1xml/examp\
+                  le"
+        "401":
+          $ref: "#/paths/~1search/get/responses/401"
+        "422":
+          $ref: "#/paths/~1search/get/responses/422"
+        default:
+          description: Some objects patched, some patches failed
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  anyOf:
+                    - type: object
+                      title: Error
+                      properties:
+                        Error:
+                          $ref: "#/paths/~1organisation/post/responses/default/cont\
+                            ent/application~1json/schema/items/anyOf/0/properti\
+                            es/Error"
+                    - type: object
+                      title: OrganisationRelationship
+                      properties:
+                        OrganisationRelationship:
+                          $ref: jsonSchema.NZ.create.yaml#/properties/OrganisationRelationship
+              example:
+                $ref: "#/paths/~1organisation~1%7BOrganisationRefId%7D~1organisatio\
+                  nrelationship/post/responses/default/content/application~1jso\
+                  n/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  Response:
+                    type: array
+                    items:
+                      anyOf:
+                        - type: object
+                          title: Error
+                          properties:
+                            Error:
+                              $ref: "#/paths/~1organisation/post/responses/default/\
+                                content/application~1xml/schema/properties/Resp\
+                                onse/items/anyOf/0/properties/Error"
+                        - type: object
+                          title: OrganisationRelationship
+                          properties:
+                            OrganisationRelationship:
+                              $ref: jsonSchema.NZ.create.yaml#/properties/OrganisationRelationship
+              example:
+                $ref: "#/paths/~1organisation~1%7BOrganisationRefId%7D~1organisatio\
+                  nrelationship/post/responses/default/content/application~1xml\
+                  /example"
+  "/organisation/{OrganisationRefId}/organisationrelationship/{OrganisationRelationshipRefId}":
+    get:
+      tags:
+        - OrganisationRelationship
+        - OrganisationRelationshipSingle
+      summary: Get a single OperationRelationship
+      description: Retrieve a particular OrganisationRelationship, which represents
+        a  single recognised relationship between two education Organisations.
+        The two organisations are referred to  as the Source Organisation and
+        the Related Organisation.</p> <p>RelationshipType records the nature of
+        the relationship between the two organisations,  and gives guidance on
+        which is the Source Organisation and which is the Related
+        Organisation.</p>
+      operationId: getOrganisationRelationship
+      security:
+        - sifDataObject:
+            - SMS
+            - FIRST
+            - SUPS
+      parameters:
+        - $ref: "#/paths/~1organisation/get/parameters/0"
+        - $ref: "#/paths/~1search/get/parameters/4"
+        - $ref: "#/paths/~1search/get/parameters/3"
+        - $ref: "#/paths/~1organisation/get/parameters/3"
+        - $ref: "#/paths/~1search/get/parameters/5"
+        - $ref: "#/paths/~1organisation~1%7BOrganisationRefId%7D~1organisationrelat\
+            ionship/get/parameters/5"
+        - $ref: "#/paths/~1organisation~1%7BOrganisationRefId%7D~1organisationrelat\
+            ionship/get/parameters/6"
+        - $ref: "#/paths/~1organisation/get/parameters/5"
+        - $ref: "#/paths/~1organisation/get/parameters/6"
+        - $ref: "#/paths/~1organisation/get/parameters/7"
+        - $ref: "#/paths/~1search/get/parameters/6"
+        - name: OrganisationRefId
+          in: path
+          required: true
+          description: <p>The Ministry of Education Organisation Id of the Provider (or
+            other Organisation) that must be either the <strong>source</strong>
+            or <strong>related</strong> Organisation of the organisation
+            relationships.
+          schema:
+            type: string
+            pattern: ^[1-9][0-9]{0,4}$
+          example: "9651"
+        - name: OrganisationRelationshipRefId
+          in: path
+          description: <p>The SIF GUID used by systems to identify the
+            OrganisationRelationship.</p>
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  OrganisationRelationship:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/OrganisationRelationship
+              example:
+                OrganisationRelationship:
+                  OrganisationRelationshipLocalId: 90100_8001
+                  Status: A
+                  RelationshipType: "34037"
+                  SourceOrganisation:
+                    RefId: "90100"
+                  SourceOrganisationRole: LSC
+                  SourceOrganisationAgreementDate: 2020-01-15
+                  RelatedOrganisation:
+                    RefId: "8001"
+                  RelatedOrganisationRole: "184000"
+                  RelatedOrganisationAgreementDate: 2020-01-15
+                  EffectiveDate: 2020-01-15
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  OrganisationRelationship:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/OrganisationRelationship
+              example: >-
+                <OrganisationRelationship>
+                  <OrganisationRelationshipLocalId>90100_8001</OrganisationRelationshipLocalId>
+                  <Status>A</Status>
+                  <RelationshipType>34037</RelationshipType>
+                  <SourceOrganisation>
+                    <RefId>90100</RefId>
+                  </SourceOrganisation>
+                  <SourceOrganisationRole>LSC</SourceOrganisationRole>
+                  <SourceOrganisationAgreementDate>2020-01-15</SourceOrganisationAgreementDate>
+                  <RelatedOrganisation>
+                    <RefId>8001</RefId>
+                  </RelatedOrganisation>
+                  <RelatedOrganisationRole>184000</RelatedOrganisationRole>
+                  <RelatedOrganisationAgreementDate>2020-01-15</RelatedOrganisationAggreementDate>
+                  <EffectiveDate>2020-01-15</EffectiveDate>
+                </OrganisationRelationship>
+        "401":
+          $ref: "#/paths/~1search/get/responses/401"
+        "422":
+          $ref: "#/paths/~1search/get/responses/422"
+        default:
+          $ref: "#/paths/~1organisation/get/responses/default"
+    put:
+      tags:
+        - OrganisationRelationship
+        - OrganisationRelationshipSingle
+      summary: Update a single OperationRelationship
+      description: Update a particular OrganisationRelationship, which represents a  single
+        recognised relationship between two education Organisations. The two
+        organisations are referred to  as the Source Organisation and the
+        Related Organisation.</p> <p>RelationshipType records the nature of the
+        relationship between the two organisations,  and gives guidance on which
+        is the Source Organisation and which is the Related Organisation.</p>
+      security:
+        - sifDataObject:
+            - FIRST
+      parameters:
+        - $ref: "#/paths/~1search/get/parameters/6"
+        - name: OrganisationRefId
+          in: path
+          required: true
+          description: <p>The Ministry of Education Organisation Id of the Provider (or
+            other Organisation) that must be either the <strong>source</strong>
+            or <strong>related</strong> Organisation of the organisation
+            relationships.
+          schema:
+            type: string
+            pattern: ^[1-9][0-9]{0,4}$
+          example: "9651"
+        - name: OrganisationRelationshipRefId
+          in: path
+          description: <p>The SIF GUID used by systems to identify the
+            OrganisationRelationship.</p>
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: CRUD operation on OrganisationRelationship
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                OrganisationRelationship:
+                  $ref: jsonSchema.NZ.create.yaml#/properties/OrganisationRelationship
+            example:
+              $ref: "#/paths/~1organisation~1%7BOrganisationRefId%7D~1organisationr\
+                elationship~1%7BOrganisationRelationshipRefId%7D/get/responses/\
+                200/content/application~1json/example"
+          application/xml:
+            schema:
+              type: object
+              properties:
+                OrganisationRelationship:
+                  $ref: jsonSchema.NZ.create.yaml#/properties/OrganisationRelationship
+            example:
+              $ref: "#/paths/~1organisation~1%7BOrganisationRefId%7D~1organisationr\
+                elationship~1%7BOrganisationRelationshipRefId%7D/get/responses/\
+                200/content/application~1xml/example"
+      responses:
+        "200":
+          description: Update successful; returns updated object
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  OrganisationRelationship:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/OrganisationRelationship
+              example:
+                $ref: "#/paths/~1organisation~1%7BOrganisationRefId%7D~1organisatio\
+                  nrelationship~1%7BOrganisationRelationshipRefId%7D/get/respon\
+                  ses/200/content/application~1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  OrganisationRelationship:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/OrganisationRelationship
+              example:
+                $ref: "#/paths/~1organisation~1%7BOrganisationRefId%7D~1organisatio\
+                  nrelationship~1%7BOrganisationRelationshipRefId%7D/get/respon\
+                  ses/200/content/application~1xml/example"
+        "401":
+          $ref: "#/paths/~1search/get/responses/401"
+        "422":
+          $ref: "#/paths/~1search/get/responses/422"
+        default:
+          $ref: "#/paths/~1organisation~1%7BOrganisationRefId%7D/put/responses/defa\
+            ult"
+    patch:
+      tags:
+        - OrganisationRelationship
+        - OrganisationRelationshipSingle
+      summary: Patch a single OperationRelationship
+      description: Update one or more fields of a particular OrganisationRelationship,
+        which represents a  single recognised relationship between two education
+        Organisations. The two organisations are referred to as the Source
+        Organisation and the Related Organisation.</p> <p>RelationshipType
+        records the nature of the relationship between the two
+        organisations,  and gives guidance on which is the Source Organisation
+        and which is the Related Organisation.</p>
+      operationId: patchOrganisationRelationship
+      security:
+        - sifDataObject:
+            - FIRST
+      parameters:
+        - $ref: "#/paths/~1search/get/parameters/6"
+        - name: OrganisationRefId
+          in: path
+          required: true
+          description: <p>The Ministry of Education Organisation Id of the Provider (or
+            other Organisation) that must be either the <strong>source</strong>
+            or <strong>related</strong> Organisation of the organisation
+            relationships.
+          schema:
+            type: string
+            pattern: ^[1-9][0-9]{0,4}$
+          example: "9651"
+        - name: OrganisationRelationshipRefId
+          in: path
+          description: <p>The SIF GUID used by systems to identify the
+            OrganisationRelationship.</p>
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: CRUD operation on OrganisationRelationship
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                OrganisationRelationship:
+                  $ref: jsonSchema.NZ.update.yaml#/properties/OrganisationRelationship
+            example:
+              $ref: "#/paths/~1organisation~1%7BOrganisationRefId%7D~1organisationr\
+                elationship~1%7BOrganisationRelationshipRefId%7D/get/responses/\
+                200/content/application~1json/example"
+          application/xml:
+            schema:
+              type: object
+              properties:
+                OrganisationRelationship:
+                  $ref: jsonSchema.NZ.update.yaml#/properties/OrganisationRelationship
+            example:
+              $ref: "#/paths/~1organisation~1%7BOrganisationRefId%7D~1organisationr\
+                elationship~1%7BOrganisationRelationshipRefId%7D/get/responses/\
+                200/content/application~1xml/example"
+      responses:
+        "200":
+          description: Patch successful; returns patched object
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  OrganisationRelationship:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/OrganisationRelationship
+              example:
+                $ref: "#/paths/~1organisation~1%7BOrganisationRefId%7D~1organisatio\
+                  nrelationship~1%7BOrganisationRelationshipRefId%7D/get/respon\
+                  ses/200/content/application~1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  OrganisationRelationship:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/OrganisationRelationship
+              example:
+                $ref: "#/paths/~1organisation~1%7BOrganisationRefId%7D~1organisatio\
+                  nrelationship~1%7BOrganisationRelationshipRefId%7D/get/respon\
+                  ses/200/content/application~1xml/example"
+        "401":
+          $ref: "#/paths/~1search/get/responses/401"
+        "422":
+          $ref: "#/paths/~1search/get/responses/422"
+        default:
+          $ref: "#/paths/~1organisation~1%7BOrganisationRefId%7D/patch/responses/de\
+            fault"
+  /staffpersonal:
+    post:
+      tags:
+        - StaffPersonal
+        - StaffPersonalBulk
+      summary: Create one or more StaffPersonals
+      description: <p>Bulk operation to create one or more StaffPersonal records of the
+        personal contact and demographic information relating to a single staff
+        member, who might be a teacher or other employee of the given
+        Provider.</p>
+      operationId: createStaffPersonals
+      parameters:
+        - $ref: "#/paths/~1organisation/post/parameters/0"
+        - $ref: "#/paths/~1search/get/parameters/6"
+        - name: X-Edsby-OrganisationRefId
+          in: header
+          required: true
+          description: <p>The Ministry of Education Organisation Id of the Provider(or
+            other Organisation); used to limit the scope of the API endpoint to
+            a particular MoE Organisation.</p>
+          schema:
+            type: string
+            pattern: ^[1-9][0-9]{0,4}$
+          example: "9651"
+      security:
+        - sifDataObject:
+            - SUPS
+            - SMS
+      requestBody:
+        description: CRUD operation on StaffPersonal
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                StaffPersonals:
+                  type: object
+                  properties:
+                    StaffPersonal:
+                      type: array
+                      items:
+                        allOf:
+                          - $ref: jsonSchema.NZ.create.yaml#/properties/StaffPersonalBase
+                          - required:
+                              - StaffAssignment
+                            properties:
+                              StaffAssignment:
+                                type: object
+                                description: >-
+                                  <p>Partial <a
+                                  href="#tag/StaffAssignment">StaffAssignment</a>
+                                  object, 
+
+                                  denoting initial role, at the given Organisation for the StaffPersonal upon creation.</p>
+                                required:
+                                  - StaffRole
+                                  - StartDate
+                                additionalProperties: false
+                                properties:
+                                  StaffRole:
+                                    $ref: jsonSchema.NZ.create.yaml#/definitions/NZCodeSetsStaffRole
+                                  StartDate:
+                                    $ref: jsonSchema.NZ.create.yaml#/properties/StaffAssignment/properties/StartDate
+                                  EndDate:
+                                    $ref: jsonSchema.NZ.create.yaml#/properties/StaffAssignment/properties/EndDate
+            example:
+              StaffPersonals:
+                StaffPersonal:
+                  - StaffPersonalRefId: d3e34f41-9d75-101a-8c3d-00aa001a1652
+                    StaffPersonalLocalId: ST-001
+                    PersonInfo:
+                      Name:
+                        FamilyName: Smith
+                        GivenName: Fred
+                        FullName: Fred Smith
+                        IsVerified: N
+                      Demographics:
+                        BirthDate: 1966-05-01
+                      EmailList:
+                        Email:
+                          - Type: PRIM
+                            Address: freddy@mailinator.com
+                    StaffAssignment:
+                      StaffRole: "1002"
+                      StartDate: 2020-09-03
+          application/xml:
+            schema:
+              type: object
+              properties:
+                StaffPersonals:
+                  type: object
+                  properties:
+                    StaffPersonal:
+                      type: array
+                      items:
+                        allOf:
+                          - $ref: jsonSchema.NZ.create.yaml#/properties/StaffPersonalBase
+                          - required:
+                              - StaffAssignment
+                            properties:
+                              StaffAssignment:
+                                type: object
+                                description: >-
+                                  <p>Partial <a
+                                  href="#tag/StaffAssignment">StaffAssignment</a>
+                                  object, 
+
+                                  denoting initial role, at the given Organisation for the StaffPersonal upon creation.</p>
+                                required:
+                                  - StaffRole
+                                  - StartDate
+                                additionalProperties: false
+                                properties:
+                                  StaffRole:
+                                    $ref: jsonSchema.NZ.create.yaml#/definitions/NZCodeSetsStaffRole
+                                  StartDate:
+                                    $ref: jsonSchema.NZ.create.yaml#/properties/StaffAssignment/properties/StartDate
+                                  EndDate:
+                                    $ref: jsonSchema.NZ.create.yaml#/properties/StaffAssignment/properties/EndDate
+            example: >-
+              <StaffPersonals>
+                <StaffPersonal>
+                  <StaffPersonalRefId>d3e34f41-9d75-101a-8c3d-00aa001a1652</StaffPersonalRefId>
+                  <StaffPersonalLocalId>ST-001</StaffPersonalLocalId>
+                  <PersonInfo>
+                    <Name>
+                      <FamilyName>Smith</FamilyName>
+                      <GivenName>Fred</GivenName>
+                      <FullName>Fred Smith</FullName>
+                      <IsVerified>N</IsVerified>
+                    </Name>
+                    <Demographics>
+                      <BirthDate>1966-05-01</BirthDate>
+                    </Demographics>          
+                    <EmailList>
+                      <Email>
+                        <Type>PRIM</Type>
+                        <Address>freddy@gmail.com</Address>
+                      </Email>
+                    </EmailList>
+                  </PersonInfo>
+                  <StaffAssignment>
+                    <StaffRole>1002</StaffRole>
+                    <StartDate>2020-09-03</StartDate>
+                  </StaffAssignment>
+                </StaffPersonal>
+                <StaffPersonal>
+                  <StaffPersonalRefId>d3e34f41-9d75-101a-8c3d-00aa001b3652</StaffPersonalRefId>
+                  <StaffPersonalLocalId>ST-002</StaffPersonalLocalId>
+                  <PersonInfo>
+                    <Name>
+                      <FullName>Fred Jones</FullName>
+                      <IsVerified>N</IsVerified>
+                    </Name>
+                    <Demographics>
+                      <BirthDate>1966-05-01</BirthDate>
+                    </Demographics>          
+                    <EmailList>
+                      <Email>
+                        <Type>PRIM</Type>
+                        <Address>fredJ@gmail.com</Address>
+                      </Email>
+                    </EmailList>
+                  </PersonInfo>
+                  <StaffAssignment>
+                    <StaffRole>1002</StaffRole>
+                    <StartDate>2020-09-03</StartDate>
+                  </StaffAssignment>
+                </StaffPersonal>      
+              </StaffPersonals>
+      responses:
+        "200":
+          description: Create successful; returns created objects
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  StaffPersonals:
+                    type: object
+                    properties:
+                      StaffPersonal:
+                        type: array
+                        items:
+                          allOf:
+                            - $ref: jsonSchema.NZ.create.yaml#/properties/StaffPersonalBase
+                            - required:
+                                - StaffAssignment
+                              properties:
+                                StaffAssignment:
+                                  type: object
+                                  description: >-
+                                    <p>Partial <a
+                                    href="#tag/StaffAssignment">StaffAssignment</a>
+                                    object, 
+
+                                    denoting initial role, at the given Organisation for the StaffPersonal upon creation.</p>
+                                  required:
+                                    - StaffRole
+                                    - StartDate
+                                  additionalProperties: false
+                                  properties:
+                                    StaffRole:
+                                      $ref: jsonSchema.NZ.create.yaml#/definitions/NZCodeSetsStaffRole
+                                    StartDate:
+                                      $ref: jsonSchema.NZ.create.yaml#/properties/StaffAssignment/properties/StartDate
+                                    EndDate:
+                                      $ref: jsonSchema.NZ.create.yaml#/properties/StaffAssignment/properties/EndDate
+              example:
+                $ref: "#/paths/~1staffpersonal/post/requestBody/content/application\
+                  ~1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  StaffPersonals:
+                    type: object
+                    properties:
+                      StaffPersonal:
+                        type: array
+                        items:
+                          allOf:
+                            - $ref: jsonSchema.NZ.create.yaml#/properties/StaffPersonalBase
+                            - required:
+                                - StaffAssignment
+                              properties:
+                                StaffAssignment:
+                                  type: object
+                                  description: >-
+                                    <p>Partial <a
+                                    href="#tag/StaffAssignment">StaffAssignment</a>
+                                    object, 
+
+                                    denoting initial role, at the given Organisation for the StaffPersonal upon creation.</p>
+                                  required:
+                                    - StaffRole
+                                    - StartDate
+                                  additionalProperties: false
+                                  properties:
+                                    StaffRole:
+                                      $ref: jsonSchema.NZ.create.yaml#/definitions/NZCodeSetsStaffRole
+                                    StartDate:
+                                      $ref: jsonSchema.NZ.create.yaml#/properties/StaffAssignment/properties/StartDate
+                                    EndDate:
+                                      $ref: jsonSchema.NZ.create.yaml#/properties/StaffAssignment/properties/EndDate
+              example:
+                $ref: "#/paths/~1staffpersonal/post/requestBody/content/application\
+                  ~1xml/example"
+        "401":
+          $ref: "#/paths/~1search/get/responses/401"
+        "422":
+          $ref: "#/paths/~1search/get/responses/422"
+        default:
+          description: Some objects created, some creates failed
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  anyOf:
+                    - type: object
+                      title: Error
+                      properties:
+                        Error:
+                          $ref: "#/paths/~1organisation/post/responses/default/cont\
+                            ent/application~1json/schema/items/anyOf/0/properti\
+                            es/Error"
+                    - type: object
+                      title: StaffPersonal
+                      properties:
+                        StaffPersonal:
+                          $ref: jsonSchema.NZ.create.yaml#/properties/StaffPersonal
+              example:
+                - StaffPersonal:
+                    - StaffPersonalRefId: d3e34f41-9d75-101a-8c3d-00aa001a1652
+                      StaffPersonalLocalId: ST-001
+                      PersonInfo:
+                        Name:
+                          FamilyName: Smith
+                          GivenName: Fred
+                          FullName: Fred Smith
+                          IsVerified: N
+                        Demographics:
+                          BirthDate: 1966-05-01
+                        EmailList:
+                          Email:
+                            - Type: PRIM
+                              Address: freddy@mailinator.com
+                      StaffAssignment:
+                        StaffRole: "1002"
+                        StartDate: 2020-09-03
+                - Error:
+                    error: 1009
+                    when: 2020-07-16T20:00:46.000Z
+                    errorstr: "Bad field: PersonInfo-Name-FamilyName: missing required
+                      field PersonInfo-Name-FamilyName (LastName) 'None'"
+                    localId: ST-002
+                    refId: null
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  Response:
+                    type: array
+                    items:
+                      anyOf:
+                        - type: object
+                          title: Error
+                          properties:
+                            Error:
+                              $ref: "#/paths/~1organisation/post/responses/default/\
+                                content/application~1xml/schema/properties/Resp\
+                                onse/items/anyOf/0/properties/Error"
+                        - type: object
+                          title: StaffPersonal
+                          properties:
+                            StaffPersonal:
+                              $ref: jsonSchema.NZ.create.yaml#/properties/StaffPersonal
+              example: >-
+                <Response>
+                  <StaffPersonal>
+                    <StaffPersonalRefId>d3e34f41-9d75-101a-8c3d-00aa001a1652</StaffPersonalRefId>
+                    <StaffPersonalLocalId>ST-001</StaffPersonalLocalId>
+                    <PersonInfo>
+                      <Name>
+                        <FamilyName>Smith</FamilyName>
+                        <GivenName>Fred</GivenName>
+                        <FullName>Fred Smith</FullName>
+                        <IsVerified>N</IsVerified>
+                      </Name>
+                      <Demographics>
+                        <BirthDate>1966-05-01</BirthDate>
+                      </Demographics>
+                      <EmailList>
+                        <Email>
+                          <Type>PRIM</Type>
+                          <Address>freddy@gmail.com</Address>
+                        </Email>
+                      </EmailList>
+                    </PersonInfo>
+                  </StaffPersonal>
+                  <Error>
+                    <error>1009</error>
+                    <when>2020-07-16T20:00:46.000Z</when>
+                    <errorstr>Bad field: PersonInfo-Name-FamilyName: missing required field PersonInfo-Name-FamilyName (LastName) 'None'</errorstr>
+                    <localId>ST-002</localId>
+                    <refId/>
+                  </Error>
+                </Response>
+    get:
+      tags:
+        - StaffPersonal
+        - StaffPersonalBulk
+      summary: Retrieve one or more StaffPersonals
+      description: <p>Bulk operation to retrieve all available StaffPersonal records of the
+        personal contact and demographic information relating to a single staff
+        member, who might be a teacher or other  employee of the given
+        Provider.</p>
+      operationId: getStaffPersonals
+      security:
+        - sifDataObject:
+            - SUPS
+            - SMS
+      parameters:
+        - $ref: "#/paths/~1organisation/get/parameters/0"
+        - $ref: "#/paths/~1search/get/parameters/4"
+        - $ref: "#/paths/~1search/get/parameters/3"
+        - $ref: "#/paths/~1organisation/get/parameters/3"
+        - $ref: "#/paths/~1search/get/parameters/5"
+        - $ref: "#/paths/~1organisation/get/parameters/5"
+        - $ref: "#/paths/~1organisation/get/parameters/6"
+        - $ref: "#/paths/~1organisation/get/parameters/7"
+        - $ref: "#/paths/~1search/get/parameters/6"
+        - $ref: "#/paths/~1staffpersonal/post/parameters/2"
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  StaffPersonals:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/StaffPersonals
+              example:
+                StaffPersonals:
+                  StaffPersonal:
+                    - StaffPersonalRefId: d3e34f41-9d75-101a-8c3d-00aa001a1652
+                      StaffPersonalLocalId: ST-001
+                      PersonInfo:
+                        Name:
+                          FamilyName: Smith
+                          GivenName: Fred
+                          FullName: Fred Smith
+                          IsVerified: N
+                        Demographics:
+                          BirthDate: 1966-05-01
+                        EmailList:
+                          Email:
+                            - Type: PRIM
+                              Address: freddy@mailinator.com
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  StaffPersonals:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/StaffPersonals
+              example: >-
+                <StaffPersonals>
+                  <StaffPersonal>
+                    <StaffPersonalRefId>d3e34f41-9d75-101a-8c3d-00aa001a1652</StaffPersonalRefId>
+                    <StaffPersonalLocalId>ST-001</StaffPersonalLocalId>
+                    <PersonInfo>
+                      <Name>
+                        <FamilyName>Smith</FamilyName>
+                        <GivenName>Fred</GivenName>
+                        <FullName>Fred Smith</FullName>
+                        <IsVerified>N</IsVerified>
+                      </Name>
+                      <Demographics>
+                        <BirthDate>1966-05-01</BirthDate>
+                      </Demographics>          
+                      <EmailList>
+                        <Email>
+                          <Type>PRIM</Type>
+                          <Address>freddy@gmail.com</Address>
+                        </Email>
+                      </EmailList>
+                    </PersonInfo>
+                  </StaffPersonal>
+                  <StaffPersonal>
+                    <StaffPersonalRefId>d3e34f41-9d75-101a-8c3d-00aa001b3652</StaffPersonalRefId>
+                    <StaffPersonalLocalId>ST-002</StaffPersonalLocalId>
+                    <PersonInfo>
+                      <Name>
+                        <FullName>Fred Jones</FullName>
+                        <IsVerified>N</IsVerified>
+                      </Name>
+                      <Demographics>
+                        <BirthDate>1966-05-01</BirthDate>
+                      </Demographics>          
+                      <EmailList>
+                        <Email>
+                          <Type>PRIM</Type>
+                          <Address>fredJ@gmail.com</Address>
+                        </Email>
+                      </EmailList>
+                    </PersonInfo>
+                  </StaffPersonal>      
+                </StaffPersonals>
+        "401":
+          $ref: "#/paths/~1search/get/responses/401"
+        "422":
+          $ref: "#/paths/~1search/get/responses/422"
+        default:
+          $ref: "#/paths/~1organisation/get/responses/default"
+    put:
+      tags:
+        - StaffPersonal
+        - StaffPersonalBulk
+      summary: Update one or more StaffPersonals
+      description: <p>Bulk operation to update one or more StaffPeraonal records of the
+        personal contact and  demographic information relating to a single staff
+        member, who might be a teacher or other employee of the given
+        Provider.</p>
+      operationId: updateStaffPersonals
+      security:
+        - sifDataObject:
+            - SUPS
+            - SMS
+      parameters:
+        - $ref: "#/paths/~1search/get/parameters/6"
+        - $ref: "#/paths/~1staffpersonal/post/parameters/2"
+      requestBody:
+        description: CRUD operation on StaffPersonal
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                StaffPersonals:
+                  $ref: jsonSchema.NZ.create.yaml#/properties/StaffPersonals
+            example:
+              $ref: "#/paths/~1staffpersonal/get/responses/200/content/application~\
+                1json/example"
+          application/xml:
+            schema:
+              type: object
+              properties:
+                StaffPersonals:
+                  $ref: jsonSchema.NZ.create.yaml#/properties/StaffPersonals
+            example:
+              $ref: "#/paths/~1staffpersonal/get/responses/200/content/application~\
+                1xml/example"
+      responses:
+        "200":
+          description: Update successful; returns updated objects
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  StaffPersonals:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/StaffPersonals
+              example:
+                $ref: "#/paths/~1staffpersonal/get/responses/200/content/applicatio\
+                  n~1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  StaffPersonals:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/StaffPersonals
+              example:
+                $ref: "#/paths/~1staffpersonal/get/responses/200/content/applicatio\
+                  n~1xml/example"
+        "401":
+          $ref: "#/paths/~1search/get/responses/401"
+        "422":
+          $ref: "#/paths/~1search/get/responses/422"
+        default:
+          description: Some objects updated, some updates failed
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  anyOf:
+                    - type: object
+                      title: Error
+                      properties:
+                        Error:
+                          $ref: "#/paths/~1organisation/post/responses/default/cont\
+                            ent/application~1json/schema/items/anyOf/0/properti\
+                            es/Error"
+                    - type: object
+                      title: StaffPersonal
+                      properties:
+                        StaffPersonal:
+                          $ref: jsonSchema.NZ.create.yaml#/properties/StaffPersonal
+              example:
+                - StaffPersonal:
+                    StaffPersonalRefId: d3e34f41-9d75-101a-8c3d-00aa001a1652
+                    StaffPersonalLocalId: ST-001
+                    PersonInfo:
+                      Name:
+                        FamilyName: Smith
+                        GivenName: Fred
+                        FullName: Fred Smith
+                        IsVerified: N
+                      Demographics:
+                        BirthDate: 1966-05-01
+                      EmailList:
+                        Email:
+                          - Type: PRIM
+                            Address: freddy@mailinator.com
+                - Error:
+                    error: 1009
+                    when: 2020-07-16T20:00:46.000Z
+                    errorstr: "Bad field: PersonInfo-Name-FamilyName: missing required
+                      field PersonInfo-Name-FamilyName (LastName) 'None'"
+                    localId: ST-002
+                    refId: null
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  Response:
+                    type: array
+                    items:
+                      anyOf:
+                        - type: object
+                          title: Error
+                          properties:
+                            Error:
+                              $ref: "#/paths/~1organisation/post/responses/default/\
+                                content/application~1xml/schema/properties/Resp\
+                                onse/items/anyOf/0/properties/Error"
+                        - type: object
+                          title: StaffPersonal
+                          properties:
+                            StaffPersonal:
+                              $ref: jsonSchema.NZ.create.yaml#/properties/StaffPersonal
+              example:
+                $ref: "#/paths/~1staffpersonal/post/responses/default/content/appli\
+                  cation~1xml/example"
+    patch:
+      tags:
+        - StaffPersonal
+        - StaffPersonalBulk
+      summary: Patch one or more StaffPersonals
+      description: <p>Bulk operation to update one or more fields of one or more
+        StaffPersonal records of the personal contact and demographic
+        information relating to a single staff member, who might be a teacher or
+        other employee of the given Provider.</p>
+      operationId: patchStaffPersonals
+      security:
+        - sifDataObject:
+            - SUPS
+            - SMS
+      parameters:
+        - $ref: "#/paths/~1search/get/parameters/6"
+        - $ref: "#/paths/~1staffpersonal/post/parameters/2"
+      requestBody:
+        description: CRUD operation on StaffPersonal
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                StaffPersonals:
+                  $ref: jsonSchema.NZ.update.yaml#/properties/StaffPersonals
+            example:
+              $ref: "#/paths/~1staffpersonal/get/responses/200/content/application~\
+                1json/example"
+          application/xml:
+            schema:
+              type: object
+              properties:
+                StaffPersonals:
+                  $ref: jsonSchema.NZ.update.yaml#/properties/StaffPersonals
+            example:
+              $ref: "#/paths/~1staffpersonal/get/responses/200/content/application~\
+                1xml/example"
+      responses:
+        "200":
+          description: Patch successful; returns patched objects
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  StaffPersonals:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/StaffPersonals
+              example:
+                $ref: "#/paths/~1staffpersonal/get/responses/200/content/applicatio\
+                  n~1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  StaffPersonals:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/StaffPersonals
+              example:
+                $ref: "#/paths/~1staffpersonal/get/responses/200/content/applicatio\
+                  n~1xml/example"
+        "401":
+          $ref: "#/paths/~1search/get/responses/401"
+        "422":
+          $ref: "#/paths/~1search/get/responses/422"
+        default:
+          description: Some objects patched, some patches failed
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  anyOf:
+                    - type: object
+                      title: Error
+                      properties:
+                        Error:
+                          $ref: "#/paths/~1organisation/post/responses/default/cont\
+                            ent/application~1json/schema/items/anyOf/0/properti\
+                            es/Error"
+                    - type: object
+                      title: StaffPersonal
+                      properties:
+                        StaffPersonal:
+                          $ref: jsonSchema.NZ.create.yaml#/properties/StaffPersonal
+              example:
+                $ref: "#/paths/~1staffpersonal/put/responses/default/content/applic\
+                  ation~1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  Response:
+                    type: array
+                    items:
+                      anyOf:
+                        - type: object
+                          title: Error
+                          properties:
+                            Error:
+                              $ref: "#/paths/~1organisation/post/responses/default/\
+                                content/application~1xml/schema/properties/Resp\
+                                onse/items/anyOf/0/properties/Error"
+                        - type: object
+                          title: StaffPersonal
+                          properties:
+                            StaffPersonal:
+                              $ref: jsonSchema.NZ.create.yaml#/properties/StaffPersonal
+              example:
+                $ref: "#/paths/~1staffpersonal/post/responses/default/content/appli\
+                  cation~1xml/example"
+  "/staffpersonal/{StaffPersonalRefId}":
+    get:
+      tags:
+        - StaffPersonal
+        - StaffPersonalSingle
+      summary: Retrieve a single StaffPersonal
+      description: Retrieve a single record of the personal contact and demographic
+        information relating to a single staff member, who might be a teacher or
+        other employee of the given Provider.</p>
+      operationId: getStaffPersonal
+      security:
+        - sifDataObject:
+            - SUPS
+            - SMS
+      parameters:
+        - $ref: "#/paths/~1organisation/get/parameters/0"
+        - $ref: "#/paths/~1search/get/parameters/4"
+        - $ref: "#/paths/~1search/get/parameters/3"
+        - $ref: "#/paths/~1organisation/get/parameters/3"
+        - $ref: "#/paths/~1search/get/parameters/5"
+        - $ref: "#/paths/~1organisation/get/parameters/5"
+        - $ref: "#/paths/~1organisation/get/parameters/6"
+        - $ref: "#/paths/~1organisation/get/parameters/7"
+        - $ref: "#/paths/~1search/get/parameters/6"
+        - $ref: "#/paths/~1staffpersonal/post/parameters/2"
+        - name: StaffPersonalRefId
+          in: path
+          description: <p>Unique identifier (GUID) that uniquely identifies the particular
+            StaffPersonal record of the personal contact and demographic
+            information relating to a single  staff member, who might be a
+            teacher or other employee of a Provider.</p>
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  StaffPersonal:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/StaffPersonal
+              example:
+                StaffPersonal:
+                  StaffPersonalRefId: d3e34f41-9d75-101a-8c3d-00aa001a1652
+                  StaffPersonalLocalId: ST-001
+                  PersonInfo:
+                    Name:
+                      FamilyName: Smith
+                      GivenName: Fred
+                      FullName: Fred Smith
+                      IsVerified: N
+                    Demographics:
+                      BirthDate: 1966-05-01
+                    EmailList:
+                      Email:
+                        - Type: PRIM
+                          Address: freddy@mailinator.com
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  StaffPersonal:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/StaffPersonal
+              example: >-
+                <StaffPersonal>
+                  <StaffPersonalRefId>d3e34f41-9d75-101a-8c3d-00aa001a1652</StaffPersonalRefId>
+                  <StaffPersonalLocalId>ST-001</StaffPersonalLocalId>
+                  <PersonInfo>
+                    <Name>
+                      <FamilyName>Smith</FamilyName>
+                      <GivenName>Fred</GivenName>
+                      <FullName>Fred Smith</FullName>
+                      <IsVerified>N</IsVerified>
+                    </Name>
+                    <Demographics>
+                      <BirthDate>1966-05-01</BirthDate>
+                    </Demographics>
+                    <EmailList>
+                      <Email>
+                        <Type>PRIM</Type>
+                        <Address>freddy@gmail.com</Address>
+                      </Email>
+                    </EmailList>
+                  </PersonInfo>
+                </StaffPersonal>
+        "401":
+          $ref: "#/paths/~1search/get/responses/401"
+        "422":
+          $ref: "#/paths/~1search/get/responses/422"
+        default:
+          $ref: "#/paths/~1organisation/get/responses/default"
+    put:
+      tags:
+        - StaffPersonal
+        - StaffPersonalSingle
+      summary: Update a single StaffPersonal
+      description: Update a single record of the personal contact and demographic
+        information relating to a single staff member, who might be a teacher or
+        other employee of the given Provider.</p>
+      security:
+        - sifDataObject:
+            - SUPS
+            - SMS
+      parameters:
+        - $ref: "#/paths/~1search/get/parameters/6"
+        - $ref: "#/paths/~1staffpersonal/post/parameters/2"
+        - name: StaffPersonalRefId
+          in: path
+          description: <p>Unique identifier (GUID) that uniquely identifies the particular
+            StaffPersonal record of the personal contact and demographic
+            information relating to a single  staff member, who might be a
+            teacher or other employee of a Provider.</p>
+          required: true
+          schema:
+            type: string
+      operationId: updateStaffPersonal
+      requestBody:
+        description: CRUD operation on StaffPersonal
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                StaffPersonal:
+                  $ref: jsonSchema.NZ.create.yaml#/properties/StaffPersonal
+            example:
+              $ref: "#/paths/~1staffpersonal~1%7BStaffPersonalRefId%7D/get/response\
+                s/200/content/application~1json/example"
+          application/xml:
+            schema:
+              type: object
+              properties:
+                StaffPersonal:
+                  $ref: jsonSchema.NZ.create.yaml#/properties/StaffPersonal
+            example:
+              $ref: "#/paths/~1staffpersonal~1%7BStaffPersonalRefId%7D/get/response\
+                s/200/content/application~1xml/example"
+      responses:
+        "200":
+          description: Update successful; returns updated object
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  StaffPersonal:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/StaffPersonal
+              example:
+                $ref: "#/paths/~1staffpersonal~1%7BStaffPersonalRefId%7D/get/respon\
+                  ses/200/content/application~1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  StaffPersonal:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/StaffPersonal
+              example:
+                $ref: "#/paths/~1staffpersonal~1%7BStaffPersonalRefId%7D/get/respon\
+                  ses/200/content/application~1xml/example"
+        "401":
+          $ref: "#/paths/~1search/get/responses/401"
+        "422":
+          $ref: "#/paths/~1search/get/responses/422"
+        default:
+          $ref: "#/paths/~1organisation~1%7BOrganisationRefId%7D/put/responses/defa\
+            ult"
+    patch:
+      tags:
+        - StaffPersonal
+        - StaffPersonalSingle
+      summary: Patch a single StaffPersonal
+      description: Update one or more fields of asingle record of the personal contact and
+        demographic information relating to a single staff member, who might be
+        a teacher or other employee of the given Provider.</p>
+      operationId: patchStaffPersonal
+      security:
+        - sifDataObject:
+            - SUPS
+            - SMS
+      parameters:
+        - $ref: "#/paths/~1search/get/parameters/6"
+        - $ref: "#/paths/~1staffpersonal/post/parameters/2"
+        - name: StaffPersonalRefId
+          in: path
+          description: <p>Unique identifier (GUID) that uniquely identifies the particular
+            StaffPersonal record of the personal contact and demographic
+            information relating to a single  staff member, who might be a
+            teacher or other employee of a Provider.</p>
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: CRUD operation on StaffPersonal
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                StaffPersonal:
+                  $ref: jsonSchema.NZ.update.yaml#/properties/StaffPersonal
+            example:
+              $ref: "#/paths/~1staffpersonal~1%7BStaffPersonalRefId%7D/get/response\
+                s/200/content/application~1json/example"
+          application/xml:
+            schema:
+              type: object
+              properties:
+                StaffPersonal:
+                  $ref: jsonSchema.NZ.update.yaml#/properties/StaffPersonal
+            example:
+              $ref: "#/paths/~1staffpersonal~1%7BStaffPersonalRefId%7D/get/response\
+                s/200/content/application~1xml/example"
+      responses:
+        "200":
+          description: Patch successful; returns patched object
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  StaffPersonal:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/StaffPersonal
+              example:
+                $ref: "#/paths/~1staffpersonal~1%7BStaffPersonalRefId%7D/get/respon\
+                  ses/200/content/application~1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  StaffPersonal:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/StaffPersonal
+              example:
+                $ref: "#/paths/~1staffpersonal~1%7BStaffPersonalRefId%7D/get/respon\
+                  ses/200/content/application~1xml/example"
+        "401":
+          $ref: "#/paths/~1search/get/responses/401"
+        "422":
+          $ref: "#/paths/~1search/get/responses/422"
+        default:
+          $ref: "#/paths/~1organisation~1%7BOrganisationRefId%7D/patch/responses/de\
+            fault"
+  /staffassignment:
+    post:
+      tags:
+        - StaffAssignment
+        - StaffAssignmentBulk
+      summary: Create one or more StaffAssignments
+      description: <p>Bulk operation to create one or more assignments of a Staff member to
+        their role at a Providers or other  Organisation.</p> <p>A staff member
+        may have only have a single role at each Provider or Kāhui Ako at any
+        one time (via the Organisation data object)</p>
+      operationId: createStaffAssignments
+      security:
+        - sifDataObject:
+            - SMS
+            - SUPS
+      parameters:
+        - $ref: "#/paths/~1organisation/post/parameters/0"
+        - $ref: "#/paths/~1search/get/parameters/6"
+        - $ref: "#/paths/~1staffpersonal/post/parameters/2"
+      requestBody:
+        description: CRUD operation on StaffAssignment
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                StaffAssignments:
+                  $ref: jsonSchema.NZ.create.yaml#/properties/StaffAssignments
+            example:
+              StaffAssignments:
+                StaffAssignment:
+                  - StaffAssignmentLocalId: 2020_T99001_8001
+                    StaffAssignmentStatus: A
+                    StaffMember:
+                      LocalId: T99001
+                    AssignedLocation:
+                      RefId: "8001"
+                    StartDate: 1995-01-02
+                    StaffRole: "1001"
+                    RecordAudit:
+                      CreatedDateTime: 2020-05-26T00:00:00+1200
+                      LastUpdatedDateTime: 2020-05-26T00:00:00+1200
+          application/xml:
+            schema:
+              type: object
+              properties:
+                StaffAssignments:
+                  $ref: jsonSchema.NZ.create.yaml#/properties/StaffAssignments
+            example: >-
+              <StaffAssignments>
+                <StaffAssignment>
+                  <StaffAssignmentLocalId>2020_T99001_8001</StaffAssignmentLocalId>
+                  <StaffAssignmentStatus>A</StaffAssignmentStatus>
+                  <StaffMember>
+                    <LocalId>T99001</LocalId>
+                  </StaffMember>
+                  <AssignedLocation>
+                    <RefId>8001</RefId>
+                  </AssignedLocation>
+                  <StartDate>1995-01-02</StartDate>
+                  <StaffRole>1001</StaffRole>
+                  <RecordAudit>
+                    <CreatedDateTime>2020-05-26</CreatedDateTime>
+                    <LastUpdatedDateTime>2020-05-26</LastUpdatedDateTime>
+                  </RecordAudit>
+                </StaffAssignment>
+              </StaffAssignments>  
+      responses:
+        "200":
+          description: Create successful; returns created objects
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  StaffAssignments:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/StaffAssignments
+              example:
+                $ref: "#/paths/~1staffassignment/post/requestBody/content/applicati\
+                  on~1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  StaffAssignments:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/StaffAssignments
+              example:
+                $ref: "#/paths/~1staffassignment/post/requestBody/content/applicati\
+                  on~1xml/example"
+        "401":
+          $ref: "#/paths/~1search/get/responses/401"
+        "422":
+          $ref: "#/paths/~1search/get/responses/422"
+        default:
+          description: Some objects created, some creates failed
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  anyOf:
+                    - type: object
+                      title: Error
+                      properties:
+                        Error:
+                          $ref: "#/paths/~1organisation/post/responses/default/cont\
+                            ent/application~1json/schema/items/anyOf/0/properti\
+                            es/Error"
+                    - type: object
+                      title: StaffAssignment
+                      properties:
+                        StaffAssignment:
+                          $ref: jsonSchema.NZ.create.yaml#/properties/StaffAssignment
+              example:
+                - StaffAssignment:
+                    StaffAssignmentLocalId: 2020_T99001_8001
+                    StaffAssignmentStatus: A
+                    StaffMember:
+                      LocalId: T99001
+                    AssignedLocation:
+                      RefId: "8001"
+                    StartDate: 1995-01-02
+                    StaffRole: "1001"
+                    RecordAudit:
+                      CreatedDateTime: 2020-05-26T00:00:00+1200
+                      LastUpdatedDateTime: 2020-05-26T00:00:00+1200
+                - Error:
+                    error: 1009
+                    when: 2020-07-16T20:00:46.000Z
+                    errorstr: "Bad field: PersonInfo-Name-FamilyName: missing required
+                      field PersonInfo-Name-FamilyName (LastName) 'None'"
+                    localId: ST-002
+                    refId: null
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  Response:
+                    type: array
+                    items:
+                      anyOf:
+                        - type: object
+                          title: Error
+                          properties:
+                            Error:
+                              $ref: "#/paths/~1organisation/post/responses/default/\
+                                content/application~1xml/schema/properties/Resp\
+                                onse/items/anyOf/0/properties/Error"
+                        - type: object
+                          title: StaffAssignment
+                          properties:
+                            StaffAssignment:
+                              $ref: jsonSchema.NZ.create.yaml#/properties/StaffAssignment
+              example: >-
+                <Response>
+                  <StaffAssignment>
+                    <StaffAssignmentLocalId>2020_T99001_8001</StaffAssignmentLocalId>
+                    <StaffAssignmentStatus>A</StaffAssignmentStatus>
+                    <StaffMember>
+                      <LocalId>T99001</LocalId>
+                    </StaffMember>
+                    <AssignedLocation>
+                      <RefId>8001</RefId>
+                    </AssignedLocation>
+                    <StartDate>1995-01-02</StartDate>
+                    <StaffRole>1001</StaffRole>
+                    <RecordAudit>
+                      <CreatedDateTime>2020-05-26</CreatedDateTime>
+                      <LastUpdatedDateTime>2020-05-26</LastUpdatedDateTime>
+                    </RecordAudit>
+                  </StaffAssignment>
+                  <Error>
+                    <error>1009</error>
+                    <when>2020-07-16T20:00:46.000Z</when>
+                    <errorstr>Bad field: PersonInfo-Name-FamilyName: missing required field PersonInfo-Name-FamilyName (LastName) 'None'</errorstr>
+                    <localId>ST-002</localId>
+                    <refId/>
+                  </Error>      
+                </Response>
+    get:
+      tags:
+        - StaffAssignment
+        - StaffAssignmentBulk
+      summary: Retrieve one or more StaffAssignments
+      description: "<p>Bulk operation to retrieve all available assignments of a Staff
+        member to their role at the given Provider or other Organisation.</p>
+        <p>A staff member may have only have a single role at each Provider or
+        Kāhui Ako at any one time (via the Organisation data object)</p>    "
+      operationId: getStaffAssignments
+      security:
+        - sifDataObject:
+            - SMS
+            - SUPS
+      parameters:
+        - $ref: "#/paths/~1organisation/get/parameters/0"
+        - $ref: "#/paths/~1search/get/parameters/4"
+        - $ref: "#/paths/~1search/get/parameters/3"
+        - $ref: "#/paths/~1organisation/get/parameters/3"
+        - $ref: "#/paths/~1search/get/parameters/5"
+        - $ref: "#/paths/~1organisation~1%7BOrganisationRefId%7D~1organisationrelat\
+            ionship/get/parameters/5"
+        - $ref: "#/paths/~1organisation~1%7BOrganisationRefId%7D~1organisationrelat\
+            ionship/get/parameters/6"
+        - $ref: "#/paths/~1organisation/get/parameters/5"
+        - $ref: "#/paths/~1organisation/get/parameters/6"
+        - $ref: "#/paths/~1organisation/get/parameters/7"
+        - $ref: "#/paths/~1search/get/parameters/6"
+        - $ref: "#/paths/~1staffpersonal/post/parameters/2"
+        - $ref: "#/paths/~1organisation~1%7BOrganisationRefId%7D~1organisationrelat\
+            ionship/get/parameters/12"
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  StaffAssignments:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/StaffAssignments
+              example:
+                $ref: "#/paths/~1staffassignment/post/requestBody/content/applicati\
+                  on~1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  StaffAssignments:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/StaffAssignments
+              example:
+                $ref: "#/paths/~1staffassignment/post/requestBody/content/applicati\
+                  on~1xml/example"
+        "401":
+          $ref: "#/paths/~1search/get/responses/401"
+        "422":
+          $ref: "#/paths/~1search/get/responses/422"
+        default:
+          $ref: "#/paths/~1organisation/get/responses/default"
+    put:
+      tags:
+        - StaffAssignment
+        - StaffAssignmentBulk
+      summary: Update one or more StaffAssignments
+      description: "<p>Bulk operation to update one or more assignments of a Staff member
+        to their role at the given Provider or other Organisation.</p> <p>A
+        staff member may have only have a single role at each Provider or Kāhui
+        Ako at any one time (via the Organisation data object)</p>    "
+      operationId: updateStaffAssignments
+      security:
+        - sifDataObject:
+            - SMS
+            - SUPS
+      parameters:
+        - $ref: "#/paths/~1search/get/parameters/6"
+        - $ref: "#/paths/~1staffpersonal/post/parameters/2"
+      requestBody:
+        description: CRUD operation on StaffAssignment
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                StaffAssignments:
+                  $ref: jsonSchema.NZ.create.yaml#/properties/StaffAssignments
+            example:
+              $ref: "#/paths/~1staffassignment/post/requestBody/content/application\
+                ~1json/example"
+          application/xml:
+            schema:
+              type: object
+              properties:
+                StaffAssignments:
+                  $ref: jsonSchema.NZ.create.yaml#/properties/StaffAssignments
+            example:
+              $ref: "#/paths/~1staffassignment/post/requestBody/content/application\
+                ~1xml/example"
+      responses:
+        "200":
+          description: Update successful; returns updated objects
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  StaffAssignments:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/StaffAssignments
+              example:
+                $ref: "#/paths/~1staffassignment/post/requestBody/content/applicati\
+                  on~1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  StaffAssignments:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/StaffAssignments
+              example:
+                $ref: "#/paths/~1staffassignment/post/requestBody/content/applicati\
+                  on~1xml/example"
+        "401":
+          $ref: "#/paths/~1search/get/responses/401"
+        "422":
+          $ref: "#/paths/~1search/get/responses/422"
+        default:
+          description: Some objects updated, some updates failed
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  anyOf:
+                    - type: object
+                      title: Error
+                      properties:
+                        Error:
+                          $ref: "#/paths/~1organisation/post/responses/default/cont\
+                            ent/application~1json/schema/items/anyOf/0/properti\
+                            es/Error"
+                    - type: object
+                      title: StaffAssignment
+                      properties:
+                        StaffAssignment:
+                          $ref: jsonSchema.NZ.create.yaml#/properties/StaffAssignment
+              example:
+                $ref: "#/paths/~1staffassignment/post/responses/default/content/app\
+                  lication~1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  Response:
+                    type: array
+                    items:
+                      anyOf:
+                        - type: object
+                          title: Error
+                          properties:
+                            Error:
+                              $ref: "#/paths/~1organisation/post/responses/default/\
+                                content/application~1xml/schema/properties/Resp\
+                                onse/items/anyOf/0/properties/Error"
+                        - type: object
+                          title: StaffAssignment
+                          properties:
+                            StaffAssignment:
+                              $ref: jsonSchema.NZ.create.yaml#/properties/StaffAssignment
+              example:
+                $ref: "#/paths/~1staffassignment/post/responses/default/content/app\
+                  lication~1xml/example"
+    patch:
+      tags:
+        - StaffAssignment
+        - StaffAssignmentBulk
+      summary: Patch one or more StaffAssignments
+      description: "<p>Bulk operation to update one or more fields of one or more
+        assignments of a Staff member to their role at the given Provider or
+        other Organisation.</p> <p>A staff member may have only have a single
+        role at each Provider or Kāhui Ako at any one time (via the Organisation
+        data object)</p>    "
+      operationId: patchStaffAssignments
+      security:
+        - sifDataObject:
+            - SMS
+            - SUPS
+      parameters:
+        - $ref: "#/paths/~1search/get/parameters/6"
+        - $ref: "#/paths/~1staffpersonal/post/parameters/2"
+      requestBody:
+        description: CRUD operation on StaffAssignment
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                StaffAssignments:
+                  $ref: jsonSchema.NZ.update.yaml#/properties/StaffAssignments
+            example:
+              $ref: "#/paths/~1staffassignment/post/requestBody/content/application\
+                ~1json/example"
+          application/xml:
+            schema:
+              type: object
+              properties:
+                StaffAssignments:
+                  $ref: jsonSchema.NZ.update.yaml#/properties/StaffAssignments
+            example:
+              $ref: "#/paths/~1staffassignment/post/requestBody/content/application\
+                ~1xml/example"
+      responses:
+        "200":
+          description: Patch successful; returns patched objects
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  StaffAssignments:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/StaffAssignments
+              example:
+                $ref: "#/paths/~1staffassignment/post/requestBody/content/applicati\
+                  on~1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  StaffAssignments:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/StaffAssignments
+              example:
+                $ref: "#/paths/~1staffassignment/post/requestBody/content/applicati\
+                  on~1xml/example"
+        "401":
+          $ref: "#/paths/~1search/get/responses/401"
+        "422":
+          $ref: "#/paths/~1search/get/responses/422"
+        default:
+          description: Some objects patched, some patches failed
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  anyOf:
+                    - type: object
+                      title: Error
+                      properties:
+                        Error:
+                          $ref: "#/paths/~1organisation/post/responses/default/cont\
+                            ent/application~1json/schema/items/anyOf/0/properti\
+                            es/Error"
+                    - type: object
+                      title: StaffAssignment
+                      properties:
+                        StaffAssignment:
+                          $ref: jsonSchema.NZ.create.yaml#/properties/StaffAssignment
+              example:
+                $ref: "#/paths/~1staffassignment/post/responses/default/content/app\
+                  lication~1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  Response:
+                    type: array
+                    items:
+                      anyOf:
+                        - type: object
+                          title: Error
+                          properties:
+                            Error:
+                              $ref: "#/paths/~1organisation/post/responses/default/\
+                                content/application~1xml/schema/properties/Resp\
+                                onse/items/anyOf/0/properties/Error"
+                        - type: object
+                          title: StaffAssignment
+                          properties:
+                            StaffAssignment:
+                              $ref: jsonSchema.NZ.create.yaml#/properties/StaffAssignment
+              example:
+                $ref: "#/paths/~1staffassignment/post/responses/default/content/app\
+                  lication~1xml/example"
+  "/staffassignment/{StaffPersonalRefId}":
+    get:
+      tags:
+        - StaffAssignment
+        - StaffAssignmentSingle
+      summary: Retrieve a single StaffAssignment
+      description: "<p>Retrieve a single assignment of a Staff member to their role at the
+        given Provider or other Organisation.</p> <p>A staff member may have
+        only have a single role at each Provider or Kāhui Ako at any one time
+        (via the Organisation data object)</p>    "
+      operationId: getStaffAssignment
+      security:
+        - sifDataObject:
+            - SMS
+            - SUPS
+      parameters:
+        - $ref: "#/paths/~1organisation/get/parameters/0"
+        - $ref: "#/paths/~1search/get/parameters/4"
+        - $ref: "#/paths/~1search/get/parameters/3"
+        - $ref: "#/paths/~1organisation/get/parameters/3"
+        - $ref: "#/paths/~1search/get/parameters/5"
+        - $ref: "#/paths/~1organisation~1%7BOrganisationRefId%7D~1organisationrelat\
+            ionship/get/parameters/5"
+        - $ref: "#/paths/~1organisation~1%7BOrganisationRefId%7D~1organisationrelat\
+            ionship/get/parameters/6"
+        - $ref: "#/paths/~1organisation/get/parameters/5"
+        - $ref: "#/paths/~1organisation/get/parameters/6"
+        - $ref: "#/paths/~1organisation/get/parameters/7"
+        - $ref: "#/paths/~1search/get/parameters/6"
+        - $ref: "#/paths/~1staffpersonal/post/parameters/2"
+        - name: StaffPersonalRefId
+          in: path
+          required: true
+          description: System RefId of the staff member.
+          schema:
+            type: string
+          example: 7b5256e7-01fe-4f5b-89e6-2e5d1e1c9a52
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  StaffAssignment:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/StaffAssignment
+              example:
+                StaffAssignment:
+                  StaffAssignmentLocalId: 2020_T99001_8001
+                  StaffAssignmentStatus: A
+                  StaffMember:
+                    LocalId: T99001
+                  AssignedLocation:
+                    RefId: "8001"
+                  StartDate: 1995-01-02
+                  StaffRole: "1001"
+                  RecordAudit:
+                    CreatedDateTime: 2020-05-26T00:00:00+1200
+                    LastUpdatedDateTime: 2020-05-26T00:00:00+1200
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  StaffAssignment:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/StaffAssignment
+              example: >-
+                <StaffAssignment>
+                  <StaffAssignmentLocalId>2020_T99001_8001</StaffAssignmentLocalId>
+                  <StaffAssignmentStatus>A</StaffAssignmentStatus>
+                  <StaffMember>
+                    <LocalId>T99001</LocalId>
+                  </StaffMember>
+                  <AssignedLocation>
+                    <RefId>8001</RefId>
+                  </AssignedLocation>
+                  <StartDate>1995-01-02</StartDate>
+                  <StaffRole>1001</StaffRole>
+                  <RecordAudit>
+                    <CreatedDateTime>2020-05-26</CreatedDateTime>
+                    <LastUpdatedDateTime>2020-05-26</LastUpdatedDateTime>
+                  </RecordAudit>
+                </StaffAssignment>
+        "401":
+          $ref: "#/paths/~1search/get/responses/401"
+        "422":
+          $ref: "#/paths/~1search/get/responses/422"
+        default:
+          $ref: "#/paths/~1organisation/get/responses/default"
+    put:
+      tags:
+        - StaffAssignment
+        - StaffAssignmentSingle
+      summary: Update a single StaffAssignment
+      description: "<p>Update a single assignment of a Staff member to their role at the
+        given Provider or other Organisation.</p> <p>A staff member may have
+        only have a single role at each Provider or Kāhui Ako at any one time
+        (via the Organisation data object)</p>    "
+      operationId: updateStaffAssignment
+      security:
+        - sifDataObject:
+            - SMS
+            - SUPS
+      parameters:
+        - $ref: "#/paths/~1search/get/parameters/6"
+        - $ref: "#/paths/~1staffpersonal/post/parameters/2"
+        - $ref: "#/paths/~1staffassignment~1%7BStaffPersonalRefId%7D/get/parameters\
+            /12"
+      requestBody:
+        description: CRUD operation on StaffAssignment
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                StaffAssignment:
+                  $ref: jsonSchema.NZ.create.yaml#/properties/StaffAssignment
+            example:
+              $ref: "#/paths/~1staffassignment~1%7BStaffPersonalRefId%7D/get/respon\
+                ses/200/content/application~1json/example"
+          application/xml:
+            schema:
+              type: object
+              properties:
+                StaffAssignment:
+                  $ref: jsonSchema.NZ.create.yaml#/properties/StaffAssignment
+            example:
+              $ref: "#/paths/~1staffassignment~1%7BStaffPersonalRefId%7D/get/respon\
+                ses/200/content/application~1xml/example"
+      responses:
+        "200":
+          description: Update successful; returns updated object
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  StaffAssignment:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/StaffAssignment
+              example:
+                $ref: "#/paths/~1staffassignment~1%7BStaffPersonalRefId%7D/get/resp\
+                  onses/200/content/application~1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  StaffAssignment:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/StaffAssignment
+              example:
+                $ref: "#/paths/~1staffassignment~1%7BStaffPersonalRefId%7D/get/resp\
+                  onses/200/content/application~1xml/example"
+        "401":
+          $ref: "#/paths/~1search/get/responses/401"
+        "422":
+          $ref: "#/paths/~1search/get/responses/422"
+        default:
+          $ref: "#/paths/~1organisation~1%7BOrganisationRefId%7D/put/responses/defa\
+            ult"
+    patch:
+      tags:
+        - StaffAssignment
+        - StaffAssignmentSingle
+      summary: Patch a single StaffAssignment
+      description: "<p>Update one or more fields of a single assignment of a Staff member
+        to their role at the given Provider or other Organisation.</p> <p>A
+        staff member may have only have a single role at each Provider or Kāhui
+        Ako at any one time (via the Organisation data object)</p>    "
+      operationId: patchStaffAssignment
+      security:
+        - sifDataObject:
+            - SMS
+            - SUPS
+      parameters:
+        - $ref: "#/paths/~1search/get/parameters/6"
+        - $ref: "#/paths/~1staffpersonal/post/parameters/2"
+        - $ref: "#/paths/~1staffassignment~1%7BStaffPersonalRefId%7D/get/parameters\
+            /12"
+      requestBody:
+        description: CRUD operation on StaffAssignment
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                StaffAssignment:
+                  $ref: jsonSchema.NZ.update.yaml#/properties/StaffAssignment
+            example:
+              $ref: "#/paths/~1staffassignment~1%7BStaffPersonalRefId%7D/get/respon\
+                ses/200/content/application~1json/example"
+          application/xml:
+            schema:
+              type: object
+              properties:
+                StaffAssignment:
+                  $ref: jsonSchema.NZ.update.yaml#/properties/StaffAssignment
+            example:
+              $ref: "#/paths/~1staffassignment~1%7BStaffPersonalRefId%7D/get/respon\
+                ses/200/content/application~1xml/example"
+      responses:
+        "200":
+          description: Patch successful; returns patched object
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  StaffAssignment:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/StaffAssignment
+              example:
+                $ref: "#/paths/~1staffassignment~1%7BStaffPersonalRefId%7D/get/resp\
+                  onses/200/content/application~1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  StaffAssignment:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/StaffAssignment
+              example:
+                $ref: "#/paths/~1staffassignment~1%7BStaffPersonalRefId%7D/get/resp\
+                  onses/200/content/application~1xml/example"
+        "401":
+          $ref: "#/paths/~1search/get/responses/401"
+        "422":
+          $ref: "#/paths/~1search/get/responses/422"
+        default:
+          $ref: "#/paths/~1organisation~1%7BOrganisationRefId%7D/patch/responses/de\
+            fault"
+  "/staffpersonal/{StaffPersonalRefId}/staffassignment":
+    get:
+      tags:
+        - StaffAssignment
+        - StaffAssignmentByStaff
+      summary: Retrieve StaffAssignments by Staff Member
+      description: "<p>Retrieve all available assignments of a particular Staff member to
+        their role at any Provider or other Organisation.</p> <p>A staff member
+        may have only have a single role at each Provider or Kāhui Ako at any
+        one time (via the Organisation data object)</p>    "
+      operationId: getStaffAssignmentsByStaff
+      parameters:
+        - $ref: "#/paths/~1organisation/get/parameters/0"
+        - $ref: "#/paths/~1search/get/parameters/4"
+        - $ref: "#/paths/~1search/get/parameters/3"
+        - $ref: "#/paths/~1organisation/get/parameters/3"
+        - $ref: "#/paths/~1search/get/parameters/5"
+        - $ref: "#/paths/~1organisation~1%7BOrganisationRefId%7D~1organisationrelat\
+            ionship/get/parameters/5"
+        - $ref: "#/paths/~1organisation~1%7BOrganisationRefId%7D~1organisationrelat\
+            ionship/get/parameters/6"
+        - $ref: "#/paths/~1organisation/get/parameters/5"
+        - $ref: "#/paths/~1organisation/get/parameters/6"
+        - $ref: "#/paths/~1organisation/get/parameters/7"
+        - $ref: "#/paths/~1staffpersonal/post/parameters/2"
+        - $ref: "#/paths/~1staffassignment~1%7BStaffPersonalRefId%7D/get/parameters\
+            /12"
+      security:
+        - sifDataObject:
+            - SMS
+            - SUPS
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  StaffAssignments:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/StaffAssignments
+              example:
+                $ref: "#/paths/~1staffassignment/post/requestBody/content/applicati\
+                  on~1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  StaffAssignments:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/StaffAssignments
+              example:
+                $ref: "#/paths/~1staffassignment/post/requestBody/content/applicati\
+                  on~1xml/example"
+        "401":
+          $ref: "#/paths/~1search/get/responses/401"
+        "422":
+          $ref: "#/paths/~1search/get/responses/422"
+        default:
+          $ref: "#/paths/~1organisation/get/responses/default"
+  /staffteachinggroupassignment:
+    post:
+      tags:
+        - StaffTeachingGroupAssignment
+        - StaffTeachingGroupAssignmentBulk
+      summary: Create one or more StaffTeachingGroupAssignments
+      description: <p>Bulk operation to create one or more assignments of Staff members to
+        particular roles with a particular TeachingGroup at the given
+        Provider</p>
+      operationId: createStaffTeachingGroupAssignments
+      security:
+        - sifDataObject:
+            - SMS
+      parameters:
+        - $ref: "#/paths/~1organisation/post/parameters/0"
+        - $ref: "#/paths/~1search/get/parameters/6"
+        - $ref: "#/paths/~1staffpersonal/post/parameters/2"
+      requestBody:
+        description: CRUD operation on StaffTeachingGroupAssignment
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                StaffTeachingGroupAssignments:
+                  $ref: jsonSchema.NZ.create.yaml#/properties/StaffTeachingGroupAssignments
+            example:
+              StaffTeachingGroupAssignments:
+                StaffTeachingGroupAssignment:
+                  - StaffTeachingGroupAssignmentLocalId: 2020_8003_HR9_T99064
+                    Status: A
+                    StaffMember:
+                      LocalId: T99064
+                    Organisation:
+                      RefId: "8003"
+                    TeachingGroup:
+                      LocalId: 2020_8003_HR9
+                    Role: "1401"
+                    StartDate: 2020-01-27
+          application/xml:
+            schema:
+              type: object
+              properties:
+                StaffTeachingGroupAssignments:
+                  $ref: jsonSchema.NZ.create.yaml#/properties/StaffTeachingGroupAssignments
+            example: >-
+              <StaffTeachingGroupAssignments>
+                <StaffTeachingGroupAssignment>
+                  <StaffTeachingGroupAssignmentLocalId>2020_8003_HR9_T99064</StaffTeachingGroupAssignmentLocalId>
+                  <StaffMember>
+                    <LocalId>T99064"</LocalId>
+                  </StaffMember>
+                  <Organisation>
+                    <RefId>8003</RefId>
+                  </Organisation>
+                  <TeachingGroup>
+                    <LocalId>2020_8003_HR9</LocalId>
+                  </TeachingGroup>
+                  <Role>1401</Role>
+                  <StartDate>2020-01-27</StartDate>
+                </StaffTeachingGroupAssignment>
+              </StaffTeachingGroupAssignments>
+      responses:
+        "200":
+          description: All objects created; returns created objects
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  StaffTeachingGroupAssignments:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/StaffTeachingGroupAssignments
+              example:
+                $ref: "#/paths/~1staffteachinggroupassignment/post/requestBody/cont\
+                  ent/application~1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  StaffTeachingGroupAssignments:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/StaffTeachingGroupAssignments
+              example:
+                $ref: "#/paths/~1staffteachinggroupassignment/post/requestBody/cont\
+                  ent/application~1xml/example"
+        "401":
+          $ref: "#/paths/~1search/get/responses/401"
+        "422":
+          $ref: "#/paths/~1search/get/responses/422"
+        default:
+          description: Some objects created, some creates failed
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  anyOf:
+                    - type: object
+                      title: Error
+                      properties:
+                        Error:
+                          $ref: "#/paths/~1organisation/post/responses/default/cont\
+                            ent/application~1json/schema/items/anyOf/0/properti\
+                            es/Error"
+                    - type: object
+                      title: StaffTeachingGroupAssignment
+                      properties:
+                        StaffTeachingGroupAssignment:
+                          $ref: jsonSchema.NZ.create.yaml#/properties/StaffTeachingGroupAssignment
+              example:
+                - StaffTeachingGroupAssignment:
+                    StaffTeachingGroupAssignmentLocalId: 2020_8003_HR9_T99064
+                    Status: A
+                    StaffMember:
+                      LocalId: T99064
+                    Organisation:
+                      RefId: "8003"
+                    TeachingGroup:
+                      LocalId: 2020_8003_HR9
+                    Role: "1401"
+                    StartDate: 2020-01-27
+                - Error:
+                    error: 1009
+                    when: 2020-07-16T20:00:46.000Z
+                    errorstr: "Bad field: PersonInfo-Name-FamilyName: missing required
+                      field PersonInfo-Name-FamilyName (LastName) 'None'"
+                    localId: ST-002
+                    refId: null
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  Response:
+                    type: array
+                    items:
+                      anyOf:
+                        - type: object
+                          title: Error
+                          properties:
+                            Error:
+                              $ref: "#/paths/~1organisation/post/responses/default/\
+                                content/application~1xml/schema/properties/Resp\
+                                onse/items/anyOf/0/properties/Error"
+                        - type: object
+                          title: StaffTeachingGroupAssignment
+                          properties:
+                            StaffTeachingGroupAssignment:
+                              $ref: jsonSchema.NZ.create.yaml#/properties/StaffTeachingGroupAssignment
+              example: >-
+                <Response>
+                  <StaffTeachingGroupAssignment>
+                    <StaffTeachingGroupAssignmentLocalId>2020_8003_HR9_T99064</StaffTeachingGroupAssignmentLocalId>
+                    <StaffMember>
+                      <LocalId>T99064"</LocalId>
+                    </StaffMember>
+                    <Organisation>
+                      <RefId>8003</RefId>
+                    </Organisation>
+                    <TeachingGroup>
+                      <LocalId>2020_8003_HR9</LocalId>
+                    </TeachingGroup>
+                    <Role>1401</Role>
+                    <StartDate>2020-01-27</StartDate>
+                  </StaffTeachingGroupAssignment>
+                  <Error>
+                    <error>1009</error>
+                    <when>2020-07-16T20:00:46.000Z</when>
+                    <errorstr>Bad field: PersonInfo-Name-FamilyName: missing required field PersonInfo-Name-FamilyName (LastName) 'None'</errorstr>
+                    <localId>ST-002</localId>
+                    <refId/>
+                  </Error>      
+                </Response>
+    get:
+      tags:
+        - StaffTeachingGroupAssignment
+        - StaffTeachingGroupAssignmentBulk
+      summary: Retreive one or more StaffTeachingGroupAssignments
+      description: <p>Bulk operation to retrieve all available assignments of Staff members
+        to particular roles with a particular TeachingGroup at the given
+        Provider</p>
+      operationId: getStaffTeachingGroupAssignments
+      security:
+        - sifDataObject:
+            - SMS
+      parameters:
+        - $ref: "#/paths/~1organisation/get/parameters/0"
+        - $ref: "#/paths/~1search/get/parameters/4"
+        - $ref: "#/paths/~1search/get/parameters/3"
+        - $ref: "#/paths/~1organisation/get/parameters/3"
+        - $ref: "#/paths/~1search/get/parameters/5"
+        - $ref: "#/paths/~1organisation~1%7BOrganisationRefId%7D~1organisationrelat\
+            ionship/get/parameters/5"
+        - $ref: "#/paths/~1organisation~1%7BOrganisationRefId%7D~1organisationrelat\
+            ionship/get/parameters/6"
+        - $ref: "#/paths/~1organisation/get/parameters/5"
+        - $ref: "#/paths/~1organisation/get/parameters/6"
+        - $ref: "#/paths/~1organisation/get/parameters/7"
+        - $ref: "#/paths/~1search/get/parameters/6"
+        - $ref: "#/paths/~1staffpersonal/post/parameters/2"
+        - $ref: "#/paths/~1organisation~1%7BOrganisationRefId%7D~1organisationrelat\
+            ionship/get/parameters/12"
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  StaffTeachingGroupAssignments:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/StaffTeachingGroupAssignments
+              example:
+                $ref: "#/paths/~1staffteachinggroupassignment/post/requestBody/cont\
+                  ent/application~1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  StaffTeachingGroupAssignments:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/StaffTeachingGroupAssignments
+              example:
+                $ref: "#/paths/~1staffteachinggroupassignment/post/requestBody/cont\
+                  ent/application~1xml/example"
+        default:
+          $ref: "#/paths/~1organisation/get/responses/default"
+    put:
+      tags:
+        - StaffTeachingGroupAssignment
+        - StaffTeachingGroupAssignmentBulk
+      summary: Update one or more StaffTeachingGroupAssignments
+      description: <p>Bulk operation to update one or more assignments of Staff members to
+        particular roles with a particular TeachingGroup at the given
+        Provider</p>
+      operationId: updateStaffTeachingGroupAssignments
+      security:
+        - sifDataObject:
+            - SMS
+      parameters:
+        - $ref: "#/paths/~1search/get/parameters/6"
+        - $ref: "#/paths/~1staffpersonal/post/parameters/2"
+      requestBody:
+        description: CRUD operation on StaffTeachingGroupAssignment
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                StaffTeachingGroupAssignments:
+                  $ref: jsonSchema.NZ.create.yaml#/properties/StaffTeachingGroupAssignments
+            example:
+              $ref: "#/paths/~1staffteachinggroupassignment/post/requestBody/conten\
+                t/application~1json/example"
+          application/xml:
+            schema:
+              type: object
+              properties:
+                StaffTeachingGroupAssignments:
+                  $ref: jsonSchema.NZ.create.yaml#/properties/StaffTeachingGroupAssignments
+            example:
+              $ref: "#/paths/~1staffteachinggroupassignment/post/requestBody/conten\
+                t/application~1xml/example"
+      responses:
+        "200":
+          description: All objects updated; returns updated objects
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  StaffTeachingGroupAssignments:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/StaffTeachingGroupAssignments
+              example:
+                $ref: "#/paths/~1staffteachinggroupassignment/post/requestBody/cont\
+                  ent/application~1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  StaffTeachingGroupAssignments:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/StaffTeachingGroupAssignments
+              example:
+                $ref: "#/paths/~1staffteachinggroupassignment/post/requestBody/cont\
+                  ent/application~1xml/example"
+        "401":
+          $ref: "#/paths/~1search/get/responses/401"
+        "422":
+          $ref: "#/paths/~1search/get/responses/422"
+        default:
+          description: Some objects created, some creates failed
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  anyOf:
+                    - type: object
+                      title: Error
+                      properties:
+                        Error:
+                          $ref: "#/paths/~1organisation/post/responses/default/cont\
+                            ent/application~1json/schema/items/anyOf/0/properti\
+                            es/Error"
+                    - type: object
+                      title: StaffTeachingGroupAssignment
+                      properties:
+                        StaffTeachingGroupAssignment:
+                          $ref: jsonSchema.NZ.create.yaml#/properties/StaffTeachingGroupAssignment
+              example:
+                $ref: "#/paths/~1staffteachinggroupassignment/post/responses/defaul\
+                  t/content/application~1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  Response:
+                    type: array
+                    items:
+                      anyOf:
+                        - type: object
+                          title: Error
+                          properties:
+                            Error:
+                              $ref: "#/paths/~1organisation/post/responses/default/\
+                                content/application~1xml/schema/properties/Resp\
+                                onse/items/anyOf/0/properties/Error"
+                        - type: object
+                          title: StaffTeachingGroupAssignment
+                          properties:
+                            StaffTeachingGroupAssignment:
+                              $ref: jsonSchema.NZ.create.yaml#/properties/StaffTeachingGroupAssignment
+              example:
+                $ref: "#/paths/~1staffteachinggroupassignment/post/responses/defaul\
+                  t/content/application~1xml/example"
+    patch:
+      tags:
+        - StaffTeachingGroupAssignment
+        - StaffTeachingGroupAssignmentBulk
+      summary: Patch one or more StaffTeachingGroupAssignments
+      description: <p>Bulk operation to update one or more fields of one or more
+        assignments of Staff members to particular roles with a particular
+        TeachingGroup at the given Provider</p>
+      operationId: patchStaffTeachingGroupAssignments
+      security:
+        - sifDataObject:
+            - SMS
+      parameters:
+        - $ref: "#/paths/~1search/get/parameters/6"
+        - $ref: "#/paths/~1staffpersonal/post/parameters/2"
+      requestBody:
+        description: CRUD operation on StaffTeachingGroupAssignment
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                StaffTeachingGroupAssignments:
+                  $ref: jsonSchema.NZ.update.yaml#/properties/StaffTeachingGroupAssignments
+            example:
+              $ref: "#/paths/~1staffteachinggroupassignment/post/requestBody/conten\
+                t/application~1json/example"
+          application/xml:
+            schema:
+              type: object
+              properties:
+                StaffTeachingGroupAssignments:
+                  $ref: jsonSchema.NZ.update.yaml#/properties/StaffTeachingGroupAssignments
+            example:
+              $ref: "#/paths/~1staffteachinggroupassignment/post/requestBody/conten\
+                t/application~1xml/example"
+      responses:
+        "200":
+          description: All objects patched; returns patched objects
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  StaffTeachingGroupAssignments:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/StaffTeachingGroupAssignments
+              example:
+                $ref: "#/paths/~1staffteachinggroupassignment/post/requestBody/cont\
+                  ent/application~1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  StaffTeachingGroupAssignments:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/StaffTeachingGroupAssignments
+              example:
+                $ref: "#/paths/~1staffteachinggroupassignment/post/requestBody/cont\
+                  ent/application~1xml/example"
+        "401":
+          $ref: "#/paths/~1search/get/responses/401"
+        "422":
+          $ref: "#/paths/~1search/get/responses/422"
+        default:
+          description: Some objects created, some creates failed
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  anyOf:
+                    - type: object
+                      title: Error
+                      properties:
+                        Error:
+                          $ref: "#/paths/~1organisation/post/responses/default/cont\
+                            ent/application~1json/schema/items/anyOf/0/properti\
+                            es/Error"
+                    - type: object
+                      title: StaffTeachingGroupAssignment
+                      properties:
+                        StaffTeachingGroupAssignment:
+                          $ref: jsonSchema.NZ.create.yaml#/properties/StaffTeachingGroupAssignment
+              example:
+                $ref: "#/paths/~1staffteachinggroupassignment/post/responses/defaul\
+                  t/content/application~1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  Response:
+                    type: array
+                    items:
+                      anyOf:
+                        - type: object
+                          title: Error
+                          properties:
+                            Error:
+                              $ref: "#/paths/~1organisation/post/responses/default/\
+                                content/application~1xml/schema/properties/Resp\
+                                onse/items/anyOf/0/properties/Error"
+                        - type: object
+                          title: StaffTeachingGroupAssignment
+                          properties:
+                            StaffTeachingGroupAssignment:
+                              $ref: jsonSchema.NZ.create.yaml#/properties/StaffTeachingGroupAssignment
+              example:
+                $ref: "#/paths/~1staffteachinggroupassignment/post/responses/defaul\
+                  t/content/application~1xml/example"
+  "/staffteachinggroupassignment/{StaffTeachingGroupAssignmentRefId}":
+    get:
+      tags:
+        - StaffTeachingGroupAssignment
+        - StaffTeachingGroupAssignmentSingle
+      summary: Retrieve a single StaffTeachingGroupAssignment
+      description: <p>Retrieve a particular assignment of a Staff member to a particular
+        role with a particular TeachingGroup at the given Provider</p>
+      operationId: getStaffTeachingGroupAssignment
+      security:
+        - sifDataObject:
+            - SMS
+      parameters:
+        - $ref: "#/paths/~1organisation/get/parameters/0"
+        - $ref: "#/paths/~1search/get/parameters/4"
+        - $ref: "#/paths/~1search/get/parameters/3"
+        - $ref: "#/paths/~1organisation/get/parameters/3"
+        - $ref: "#/paths/~1search/get/parameters/5"
+        - $ref: "#/paths/~1organisation~1%7BOrganisationRefId%7D~1organisationrelat\
+            ionship/get/parameters/5"
+        - $ref: "#/paths/~1organisation~1%7BOrganisationRefId%7D~1organisationrelat\
+            ionship/get/parameters/6"
+        - $ref: "#/paths/~1organisation/get/parameters/5"
+        - $ref: "#/paths/~1organisation/get/parameters/6"
+        - $ref: "#/paths/~1organisation/get/parameters/7"
+        - $ref: "#/paths/~1search/get/parameters/6"
+        - $ref: "#/paths/~1staffpersonal/post/parameters/2"
+        - name: StaffTeachingGroupAssignmentRefId
+          in: path
+          description: <p>The GUID that uniquely identifies a particular staff teaching
+            group assignment.</p>
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  StaffTeachingGroupAssignment:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/StaffTeachingGroupAssignment
+              example:
+                StaffTeachingGroupAssignment:
+                  StaffTeachingGroupAssignmentLocalId: 2020_8003_HR9_T99064
+                  Status: A
+                  StaffMember:
+                    LocalId: T99064
+                  Organisation:
+                    RefId: "8003"
+                  TeachingGroup:
+                    LocalId: 2020_8003_HR9
+                  Role: "1401"
+                  StartDate: 2020-01-27
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  StaffTeachingGroupAssignment:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/StaffTeachingGroupAssignment
+              example: >-
+                <StaffTeachingGroupAssignment>
+                  <StaffTeachingGroupAssignmentLocalId>2020_8003_HR9_T99064</StaffTeachingGroupAssignmentLocalId>
+                  <StaffMember>
+                    <LocalId>T99064"</LocalId>
+                  </StaffMember>
+                  <Organisation>
+                    <RefId>8003</RefId>
+                  </Organisation>
+                  <TeachingGroup>
+                    <LocalId>2020_8003_HR9</LocalId>
+                  </TeachingGroup>
+                  <Role>1401</Role>
+                  <StartDate>2020-01-27</StartDate>
+                </StaffTeachingGroupAssignment>    
+        "401":
+          $ref: "#/paths/~1search/get/responses/401"
+        "422":
+          $ref: "#/paths/~1search/get/responses/422"
+        default:
+          $ref: "#/paths/~1organisation/get/responses/default"
+    put:
+      tags:
+        - StaffTeachingGroupAssignment
+        - StaffTeachingGroupAssignmentSingle
+      summary: Update a single StaffTeachingGroupAssignment
+      description: <p>Update a particular assignment of a Staff member to a particular role
+        with a particular TeachingGroup at the given Provider</p>
+      operationId: updateStaffTeachingGroupAssignment
+      security:
+        - sifDataObject:
+            - SMS
+      parameters:
+        - $ref: "#/paths/~1search/get/parameters/6"
+        - $ref: "#/paths/~1staffpersonal/post/parameters/2"
+        - name: StaffTeachingGroupAssignmentRefId
+          in: path
+          description: <p>The GUID that uniquely identifies a particular staff teaching
+            group assignment.</p>
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: CRUD operation on StaffTeachingGroupAssignment
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                StaffTeachingGroupAssignment:
+                  $ref: jsonSchema.NZ.create.yaml#/properties/StaffTeachingGroupAssignment
+            example:
+              $ref: "#/paths/~1staffteachinggroupassignment~1%7BStaffTeachingGroupA\
+                ssignmentRefId%7D/get/responses/200/content/application~1json/e\
+                xample"
+          application/xml:
+            schema:
+              type: object
+              properties:
+                StaffTeachingGroupAssignment:
+                  $ref: jsonSchema.NZ.create.yaml#/properties/StaffTeachingGroupAssignment
+            example:
+              $ref: "#/paths/~1staffteachinggroupassignment~1%7BStaffTeachingGroupA\
+                ssignmentRefId%7D/get/responses/200/content/application~1xml/ex\
+                ample"
+      responses:
+        "200":
+          description: Update successful; returns updated object
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  StaffTeachingGroupAssignment:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/StaffTeachingGroupAssignment
+              example:
+                $ref: "#/paths/~1staffteachinggroupassignment~1%7BStaffTeachingGrou\
+                  pAssignmentRefId%7D/get/responses/200/content/application~1js\
+                  on/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  StaffTeachingGroupAssignment:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/StaffTeachingGroupAssignment
+              example:
+                $ref: "#/paths/~1staffteachinggroupassignment~1%7BStaffTeachingGrou\
+                  pAssignmentRefId%7D/get/responses/200/content/application~1xm\
+                  l/example"
+        "401":
+          $ref: "#/paths/~1search/get/responses/401"
+        "422":
+          $ref: "#/paths/~1search/get/responses/422"
+        default:
+          $ref: "#/paths/~1organisation~1%7BOrganisationRefId%7D/put/responses/defa\
+            ult"
+    patch:
+      tags:
+        - StaffTeachingGroupAssignment
+        - StaffTeachingGroupAssignmentSingle
+      summary: Patch a single StaffTeachingGroupAssignment
+      description: <p>Update one or more fields of a particular assignment of a Staff
+        member to a particular role with a particular TeachingGroup at the given
+        Provider</p>
+      operationId: patchStaffTeachingGroupAssignment
+      security:
+        - sifDataObject:
+            - SMS
+      parameters:
+        - $ref: "#/paths/~1search/get/parameters/6"
+        - $ref: "#/paths/~1staffpersonal/post/parameters/2"
+        - name: StaffTeachingGroupAssignmentRefId
+          in: path
+          description: <p>The GUID that uniquely identifies a particular staff teaching
+            group assignment.</p>
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: CRUD operation on StaffTeachingGroupAssignment
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                StaffTeachingGroupAssignment:
+                  $ref: jsonSchema.NZ.update.yaml#/properties/StaffTeachingGroupAssignment
+            example:
+              $ref: "#/paths/~1staffteachinggroupassignment~1%7BStaffTeachingGroupA\
+                ssignmentRefId%7D/get/responses/200/content/application~1json/e\
+                xample"
+          application/xml:
+            schema:
+              type: object
+              properties:
+                StaffTeachingGroupAssignment:
+                  $ref: jsonSchema.NZ.update.yaml#/properties/StaffTeachingGroupAssignment
+            example:
+              $ref: "#/paths/~1staffteachinggroupassignment~1%7BStaffTeachingGroupA\
+                ssignmentRefId%7D/get/responses/200/content/application~1xml/ex\
+                ample"
+      responses:
+        "200":
+          description: Patch successful; returns patched object
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  StaffTeachingGroupAssignment:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/StaffTeachingGroupAssignment
+              example:
+                $ref: "#/paths/~1staffteachinggroupassignment~1%7BStaffTeachingGrou\
+                  pAssignmentRefId%7D/get/responses/200/content/application~1js\
+                  on/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  StaffTeachingGroupAssignment:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/StaffTeachingGroupAssignment
+              example:
+                $ref: "#/paths/~1staffteachinggroupassignment~1%7BStaffTeachingGrou\
+                  pAssignmentRefId%7D/get/responses/200/content/application~1xm\
+                  l/example"
+        "401":
+          $ref: "#/paths/~1search/get/responses/401"
+        "422":
+          $ref: "#/paths/~1search/get/responses/422"
+        default:
+          $ref: "#/paths/~1organisation~1%7BOrganisationRefId%7D/patch/responses/de\
+            fault"
+  "/staffpersonal/{StaffPersonalRefId}/staffteachinggroupassignment":
+    get:
+      tags:
+        - StaffTeachingGroupAssignment
+        - StaffTeachingGroupAssignmentSearch
+      summary: Retrieve StaffTeachingGroupAssignments by Staff member
+      description: <p>Retrieve all available assignments of a particular Staff member to
+        any role with any TeachingGroup at the given Provider</p>
+      operationId: getStaffTeachingGroupAssignmentByStaff
+      security:
+        - sifDataObject:
+            - SMS
+      parameters:
+        - $ref: "#/paths/~1organisation/get/parameters/0"
+        - $ref: "#/paths/~1search/get/parameters/4"
+        - $ref: "#/paths/~1search/get/parameters/3"
+        - $ref: "#/paths/~1organisation/get/parameters/3"
+        - $ref: "#/paths/~1search/get/parameters/5"
+        - $ref: "#/paths/~1organisation~1%7BOrganisationRefId%7D~1organisationrelat\
+            ionship/get/parameters/5"
+        - $ref: "#/paths/~1organisation~1%7BOrganisationRefId%7D~1organisationrelat\
+            ionship/get/parameters/6"
+        - $ref: "#/paths/~1organisation/get/parameters/5"
+        - $ref: "#/paths/~1organisation/get/parameters/6"
+        - $ref: "#/paths/~1organisation/get/parameters/7"
+        - $ref: "#/paths/~1search/get/parameters/6"
+        - $ref: "#/paths/~1staffpersonal/post/parameters/2"
+        - $ref: "#/paths/~1staffassignment~1%7BStaffPersonalRefId%7D/get/parameters\
+            /12"
+        - $ref: "#/paths/~1organisation~1%7BOrganisationRefId%7D~1organisationrelat\
+            ionship/get/parameters/12"
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  StaffTeachingGroupAssignments:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/StaffTeachingGroupAssignments
+              example:
+                $ref: "#/paths/~1staffteachinggroupassignment/post/requestBody/cont\
+                  ent/application~1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  StaffTeachingGroupAssignments:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/StaffTeachingGroupAssignments
+              example:
+                $ref: "#/paths/~1staffteachinggroupassignment/post/requestBody/cont\
+                  ent/application~1xml/example"
+        default:
+          $ref: "#/paths/~1organisation/get/responses/default"
+  "/teachinggroup/{TeachingGroupRefId}/staffteachinggroupassignment":
+    get:
+      tags:
+        - StaffTeachingGroupAssignment
+        - StaffTeachingGroupAssignmentSearch
+      summary: Retrieve StaffTeachingGroupAssignments by TeachingGroup
+      description: <p>Retrieve all available assignments of any staff members to  a
+        particulr TeachingGroup at the given Provider</p>
+      operationId: getStaffTeachingGroupAssignmentByTeachingGroup
+      security:
+        - sifDataObject:
+            - SMS
+      parameters:
+        - $ref: "#/paths/~1organisation/get/parameters/0"
+        - $ref: "#/paths/~1search/get/parameters/4"
+        - $ref: "#/paths/~1search/get/parameters/3"
+        - $ref: "#/paths/~1organisation/get/parameters/3"
+        - $ref: "#/paths/~1search/get/parameters/5"
+        - $ref: "#/paths/~1organisation~1%7BOrganisationRefId%7D~1organisationrelat\
+            ionship/get/parameters/5"
+        - $ref: "#/paths/~1organisation~1%7BOrganisationRefId%7D~1organisationrelat\
+            ionship/get/parameters/6"
+        - $ref: "#/paths/~1organisation/get/parameters/5"
+        - $ref: "#/paths/~1organisation/get/parameters/6"
+        - $ref: "#/paths/~1organisation/get/parameters/7"
+        - $ref: "#/paths/~1search/get/parameters/6"
+        - $ref: "#/paths/~1staffpersonal/post/parameters/2"
+        - name: TeachingGroupRefId
+          in: path
+          required: true
+          description: <p>The GUID of the TeachingGroup</p>
+          schema:
+            type: string
+          example: a95c6a41-caa8-46a5-a78e-1cde7cf311bc
+        - $ref: "#/paths/~1organisation~1%7BOrganisationRefId%7D~1organisationrelat\
+            ionship/get/parameters/12"
+        - name: StaffTeachingGroupAssignmentRefId
+          in: path
+          description: <p>The GUID that uniquely identifies a particular staff teaching
+            group assignment.</p>
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  StaffTeachingGroupAssignments:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/StaffTeachingGroupAssignments
+              example:
+                $ref: "#/paths/~1staffteachinggroupassignment/post/requestBody/cont\
+                  ent/application~1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  StaffTeachingGroupAssignments:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/StaffTeachingGroupAssignments
+              example:
+                $ref: "#/paths/~1staffteachinggroupassignment/post/requestBody/cont\
+                  ent/application~1xml/example"
+        default:
+          $ref: "#/paths/~1organisation/get/responses/default"
+  /teachinggroup:
+    post:
+      tags:
+        - TeachingGroup
+        - TeachingGroupBulk
+      summary: Create one or more TeachingGroups
+      description: <p>Bulk operation to create one or more TeachingGroups which can have
+        multiple staff  assigned in a variety of roles (via <a
+        href="#tag/StaffTeachingGroupAssignment">StaffTeachingGroupAssignment</a>),  may
+        be assigned students from multiple year levels (via <a
+        href="#tag/StudentTeachingGroupEnrolment">StudentTeachingGroupEnrolment</a>),
+        and may be taught multiple <a
+        href="#tag/ProviderCourse">ProviderCourses</a>.</p>
+      operationId: createTeachingGroups
+      security:
+        - sifDataObject:
+            - SMS
+      parameters:
+        - $ref: "#/paths/~1organisation/post/parameters/0"
+        - $ref: "#/paths/~1search/get/parameters/6"
+        - $ref: "#/paths/~1staffpersonal/post/parameters/2"
+      requestBody:
+        description: CRUD operation on TeachingGroup
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                TeachingGroups:
+                  $ref: jsonSchema.NZ.create.yaml#/properties/TeachingGroups
+            example:
+              TeachingGroups:
+                TeachingGroup:
+                  - TeachingGroupLocalId: 2020_8003_HR9
+                    ShortName: HR_9
+                    LongName: Homeroom Year 9
+                    GroupType: RC
+                    Organisation:
+                      RefId: "8003"
+                    ScheduleTerm:
+                      LocalId: 2020_8003_Y
+                    YearLevelList:
+                      YearLevel:
+                        - 9
+          application/xml:
+            schema:
+              type: object
+              properties:
+                TeachingGroup:
+                  $ref: jsonSchema.NZ.create.yaml#/properties/TeachingGroup
+            example: |-
+              <TeachingGroups>
+                <TeachingGroup>
+                  <TeachingGroupLocalId>2020_8003_HR9</TeachingGroupLocalId>
+                  <ShortName>HR_9<ShortName>
+                  <LongName>Homeroom Year 9</LongName>
+                  <GroupType>RC</GroupType>
+                  <Organisation>
+                    <RefId>8003</RefId>
+                  </Organisation>
+                  <ScheduleTerm>
+                    <LocalId>2020_8003_Y</LocalId>
+                  </ScheduleTerm>
+                  <YearLevelList>
+                    <YearLevel>9</YearLevel>
+                  </YearLevelList>
+                </TeachingGroup>
+                <TeachingGroup>
+                  <TeachingGroupLocalId>2020_8003_HR10</TeachingGroupLocalId>
+                  <ShortName>HR_10</ShortName>
+                  <LongName>Homeroom Year 10</LongName>
+                  <GroupType>RC</GroupType>
+                  <Organisation>
+                    <RefId>8003</RefId>
+                  </Organisation>
+                  <ScheduleTerm>
+                    <LocalId>2020_8003_Y</LocalId>
+                  </ScheduleTerm>
+                  <YearLevelList>
+                    <YearLevel>10</YearLevel>
+                  </YearLevelList>
+                </TeachingGroup>
+              </TeachingGroups>
+      responses:
+        "200":
+          description: Create successful; returns created objects
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  TeachingGroups:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/TeachingGroups
+              example:
+                $ref: "#/paths/~1teachinggroup/post/requestBody/content/application\
+                  ~1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  TeachingGroup:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/TeachingGroup
+              example:
+                $ref: "#/paths/~1teachinggroup/post/requestBody/content/application\
+                  ~1xml/example"
+        "401":
+          $ref: "#/paths/~1search/get/responses/401"
+        "422":
+          $ref: "#/paths/~1search/get/responses/422"
+        default:
+          description: Some objects created, some creates failed
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  anyOf:
+                    - type: object
+                      title: Error
+                      properties:
+                        Error:
+                          $ref: "#/paths/~1organisation/post/responses/default/cont\
+                            ent/application~1json/schema/items/anyOf/0/properti\
+                            es/Error"
+                    - type: object
+                      title: TeachingGroup
+                      properties:
+                        TeachingGroup:
+                          $ref: jsonSchema.NZ.create.yaml#/properties/TeachingGroup
+              example:
+                - TeachingGroup:
+                    TeachingGroupLocalId: 2020_8003_HR9
+                    ShortName: HR_9
+                    LongName: Homeroom Year 9
+                    GroupType: RC
+                    Organisation:
+                      RefId: "8003"
+                    ScheduleTerm:
+                      LocalId: 2020_8003_Y
+                    YearLevelList:
+                      YearLevel:
+                        - 9
+                - Error:
+                    error: 1009
+                    when: 2020-07-16T20:00:46.000Z
+                    errorstr: "Bad field: PersonInfo-Name-FamilyName: missing required
+                      field PersonInfo-Name-FamilyName (LastName) 'None'"
+                    localId: ST-002
+                    refId: null
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  Response:
+                    type: array
+                    items:
+                      anyOf:
+                        - type: object
+                          title: Error
+                          properties:
+                            Error:
+                              $ref: "#/paths/~1organisation/post/responses/default/\
+                                content/application~1xml/schema/properties/Resp\
+                                onse/items/anyOf/0/properties/Error"
+                        - type: object
+                          title: TeachingGroup
+                          properties:
+                            Provider:
+                              $ref: jsonSchema.NZ.create.yaml#/properties/TeachingGroup
+              example: >-
+                <Response>
+                  <TeachingGroup>
+                    <TeachingGroupLocalId>2020_8003_HR9</TeachingGroupLocalId>
+                    <ShortName>HR_9<ShortName>
+                    <LongName>Homeroom Year 9</LongName>
+                    <GroupType>RC</GroupType>
+                    <Organisation>
+                      <RefId>8003</RefId>
+                    </Organisation>
+                    <ScheduleTerm>
+                      <LocalId>2020_8003_Y</LocalId>
+                    </ScheduleTerm>
+                    <YearLevelList>
+                      <YearLevel>9</YearLevel>
+                    </YearLevelList>
+                  </TeachingGroup> 
+                  <Error>
+                    <error>1009</error>
+                    <when>2020-07-16T20:00:46.000Z</when>
+                    <errorstr>Bad field: PersonInfo-Name-FamilyName: missing required field PersonInfo-Name-FamilyName (LastName) 'None'</errorstr>
+                    <localId>ST-002</localId>
+                    <refId/>
+                  </Error>      
+                </Response>
+    get:
+      tags:
+        - TeachingGroup
+        - TeachingGroupBulk
+      summary: Create one or more TeachingGroups
+      description: <p>Bulk operation to retrieve all available TeachingGroups from the
+        given Provider.  TeachingGroups can have multiple staff  assigned in a
+        variety of roles (via <a
+        href="#tag/StaffTeachingGroupAssignment">StaffTeachingGroupAssignment</a>),  may
+        be assigned students from multiple year levels (via <a
+        href="#tag/StudentTeachingGroupEnrolment">StudentTeachingGroupEnrolment</a>),
+        and may be taught multiple <a
+        href="#tag/ProviderCourse">ProviderCourses</a>.</p>
+      operationId: getTeachingGroups
+      security:
+        - sifDataObject:
+            - SMS
+      parameters:
+        - $ref: "#/paths/~1organisation/get/parameters/0"
+        - $ref: "#/paths/~1search/get/parameters/4"
+        - $ref: "#/paths/~1search/get/parameters/3"
+        - $ref: "#/paths/~1organisation/get/parameters/3"
+        - $ref: "#/paths/~1search/get/parameters/5"
+        - $ref: "#/paths/~1organisation/get/parameters/5"
+        - $ref: "#/paths/~1organisation/get/parameters/6"
+        - $ref: "#/paths/~1organisation/get/parameters/7"
+        - $ref: "#/paths/~1search/get/parameters/6"
+        - $ref: "#/paths/~1staffpersonal/post/parameters/2"
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  TeachingGroups:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/TeachingGroups
+              example:
+                $ref: "#/paths/~1teachinggroup/post/requestBody/content/application\
+                  ~1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  TeachingGroup:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/TeachingGroup
+              example:
+                $ref: "#/paths/~1teachinggroup/post/requestBody/content/application\
+                  ~1xml/example"
+        "401":
+          $ref: "#/paths/~1search/get/responses/401"
+        "422":
+          $ref: "#/paths/~1search/get/responses/422"
+        default:
+          $ref: "#/paths/~1organisation/get/responses/default"
+    put:
+      tags:
+        - TeachingGroup
+        - TeachingGroupBulk
+      summary: Create one or more TeachingGroups
+      description: <p>Bulk operation to update one or more TeachingGroups, which can have
+        multiple staff  assigned in a variety of roles (via <a
+        href="#tag/StaffTeachingGroupAssignment">StaffTeachingGroupAssignment</a>),  may
+        be assigned students from multiple year levels (via <a
+        href="#tag/StudentTeachingGroupEnrolment">StudentTeachingGroupEnrolment</a>),
+        and may be taught multiple <a
+        href="#tag/ProviderCourse">ProviderCourses</a>.</p>
+      operationId: updateTeachingGroups
+      security:
+        - sifDataObject:
+            - SMS
+      parameters:
+        - $ref: "#/paths/~1search/get/parameters/6"
+        - $ref: "#/paths/~1staffpersonal/post/parameters/2"
+      requestBody:
+        description: CRUD operation on TeachingGroup
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                TeachingGroups:
+                  $ref: jsonSchema.NZ.create.yaml#/properties/TeachingGroups
+            example:
+              $ref: "#/paths/~1teachinggroup/post/requestBody/content/application~1\
+                json/example"
+          application/xml:
+            schema:
+              type: object
+              properties:
+                TeachingGroup:
+                  $ref: jsonSchema.NZ.create.yaml#/properties/TeachingGroup
+            example:
+              $ref: "#/paths/~1teachinggroup/post/requestBody/content/application~1\
+                xml/example"
+      responses:
+        "200":
+          description: Updatae successful; returns updated objects
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  TeachingGroups:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/TeachingGroups
+              example:
+                $ref: "#/paths/~1teachinggroup/post/requestBody/content/application\
+                  ~1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  TeachingGroup:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/TeachingGroup
+              example:
+                $ref: "#/paths/~1teachinggroup/post/requestBody/content/application\
+                  ~1xml/example"
+        "401":
+          $ref: "#/paths/~1search/get/responses/401"
+        "422":
+          $ref: "#/paths/~1search/get/responses/422"
+        default:
+          description: Some objects updated, some updates failed
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  anyOf:
+                    - type: object
+                      title: Error
+                      properties:
+                        Error:
+                          $ref: "#/paths/~1organisation/post/responses/default/cont\
+                            ent/application~1json/schema/items/anyOf/0/properti\
+                            es/Error"
+                    - type: object
+                      title: TeachingGroup
+                      properties:
+                        TeachingGroup:
+                          $ref: jsonSchema.NZ.create.yaml#/properties/TeachingGroup
+              example:
+                $ref: "#/paths/~1teachinggroup/post/responses/default/content/appli\
+                  cation~1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  Response:
+                    type: array
+                    items:
+                      anyOf:
+                        - type: object
+                          title: Error
+                          properties:
+                            Error:
+                              $ref: "#/paths/~1organisation/post/responses/default/\
+                                content/application~1xml/schema/properties/Resp\
+                                onse/items/anyOf/0/properties/Error"
+                        - type: object
+                          title: TeachingGroup
+                          properties:
+                            Provider:
+                              $ref: jsonSchema.NZ.create.yaml#/properties/TeachingGroup
+              example:
+                $ref: "#/paths/~1teachinggroup/post/responses/default/content/appli\
+                  cation~1xml/example"
+    patch:
+      tags:
+        - TeachingGroup
+        - TeachingGroupBulk
+      summary: Patch one or more TeachingGroups
+      description: <p>Bulk operation to update one or more fields of one or more
+        TeachingGroups, which can have multiple staff  assigned in a variety of
+        roles (via <a
+        href="#tag/StaffTeachingGroupAssignment">StaffTeachingGroupAssignment</a>),  may
+        be assigned students from multiple year levels (via <a
+        href="#tag/StudentTeachingGroupEnrolment">StudentTeachingGroupEnrolment</a>),
+        and may be taught multiple <a
+        href="#tag/ProviderCourse">ProviderCourses</a>.</p>
+      operationId: patchTeachingGroups
+      security:
+        - sifDataObject:
+            - SMS
+      parameters:
+        - $ref: "#/paths/~1search/get/parameters/6"
+        - $ref: "#/paths/~1staffpersonal/post/parameters/2"
+      requestBody:
+        description: CRUD operation on TeachingGroup
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                TeachingGroups:
+                  $ref: jsonSchema.NZ.update.yaml#/properties/TeachingGroups
+            example:
+              $ref: "#/paths/~1teachinggroup/post/requestBody/content/application~1\
+                json/example"
+          application/xml:
+            schema:
+              type: object
+              properties:
+                TeachingGroup:
+                  $ref: jsonSchema.NZ.update.yaml#/properties/TeachingGroup
+            example:
+              $ref: "#/paths/~1teachinggroup/post/requestBody/content/application~1\
+                xml/example"
+      responses:
+        "200":
+          description: Patch successful; returns patched objects
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  TeachingGroups:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/TeachingGroups
+              example:
+                $ref: "#/paths/~1teachinggroup/post/requestBody/content/application\
+                  ~1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  TeachingGroup:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/TeachingGroup
+              example:
+                $ref: "#/paths/~1teachinggroup/post/requestBody/content/application\
+                  ~1xml/example"
+        "401":
+          $ref: "#/paths/~1search/get/responses/401"
+        "422":
+          $ref: "#/paths/~1search/get/responses/422"
+        default:
+          description: Some objects patched, some patches failed
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  anyOf:
+                    - type: object
+                      title: Error
+                      properties:
+                        Error:
+                          $ref: "#/paths/~1organisation/post/responses/default/cont\
+                            ent/application~1json/schema/items/anyOf/0/properti\
+                            es/Error"
+                    - type: object
+                      title: TeachingGroup
+                      properties:
+                        TeachingGroup:
+                          $ref: jsonSchema.NZ.create.yaml#/properties/TeachingGroup
+              example:
+                $ref: "#/paths/~1teachinggroup/post/responses/default/content/appli\
+                  cation~1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  Response:
+                    type: array
+                    items:
+                      anyOf:
+                        - type: object
+                          title: Error
+                          properties:
+                            Error:
+                              $ref: "#/paths/~1organisation/post/responses/default/\
+                                content/application~1xml/schema/properties/Resp\
+                                onse/items/anyOf/0/properties/Error"
+                        - type: object
+                          title: TeachingGroup
+                          properties:
+                            Provider:
+                              $ref: jsonSchema.NZ.create.yaml#/properties/TeachingGroup
+              example:
+                $ref: "#/paths/~1teachinggroup/post/responses/default/content/appli\
+                  cation~1xml/example"
+  "/teachinggroup/{TeachingGroupRefId}":
+    get:
+      tags:
+        - TeachingGroup
+        - TeachingGroupSingle
+      summary: Retrieve a single TeachingGroup
+      description: <p>Retrieve a particular TeachingGroup, which can have multiple staff
+        assigned in a variety of roles (via <a
+        href="#tag/StaffTeachingGroupAssignment">StaffTeachingGroupAssignment</a>),  may
+        be assigned students from multiple year levels (via <a
+        href="#tag/StudentTeachingGroupEnrolment">StudentTeachingGroupEnrolment</a>),
+        and may be taught multiple <a
+        href="#tag/ProviderCourse">ProviderCourses</a>.</p>
+      operationId: getTeachingGroup
+      security:
+        - sifDataObject:
+            - SMS
+      parameters:
+        - $ref: "#/paths/~1organisation/get/parameters/0"
+        - $ref: "#/paths/~1search/get/parameters/4"
+        - $ref: "#/paths/~1search/get/parameters/3"
+        - $ref: "#/paths/~1organisation/get/parameters/3"
+        - $ref: "#/paths/~1search/get/parameters/5"
+        - $ref: "#/paths/~1organisation/get/parameters/5"
+        - $ref: "#/paths/~1organisation/get/parameters/6"
+        - $ref: "#/paths/~1organisation/get/parameters/7"
+        - $ref: "#/paths/~1search/get/parameters/6"
+        - $ref: "#/paths/~1staffpersonal/post/parameters/2"
+        - $ref: "#/paths/~1teachinggroup~1%7BTeachingGroupRefId%7D~1staffteachinggr\
+            oupassignment/get/parameters/12"
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  TeachingGroup:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/TeachingGroup
+              example:
+                TeachingGroup:
+                  TeachingGroupLocalId: 2020_8003_HR9
+                  ShortName: HR_9
+                  LongName: Homeroom Year 9
+                  GroupType: RC
+                  Organisation:
+                    RefId: "8003"
+                  ScheduleTerm:
+                    LocalId: 2020_8003_Y
+                  YearLevelList:
+                    YearLevel:
+                      - 9
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  TeachingGroup:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/TeachingGroup
+              example: |-
+                <TeachingGroup>
+                  <TeachingGroupLocalId>2020_8003_HR9</TeachingGroupLocalId>
+                  <ShortName>HR_9<ShortName>
+                  <LongName>Homeroom Year 9</LongName>
+                  <GroupType>RC</GroupType>
+                  <Organisation>
+                    <RefId>8003</RefId>
+                  </Organisation>
+                  <ScheduleTerm>
+                    <LocalId>2020_8003_Y</LocalId>
+                  </ScheduleTerm>
+                  <YearLevelList>
+                    <YearLevel>9</YearLevel>
+                  </YearLevelList>
+                </TeachingGroup>  
+        "401":
+          $ref: "#/paths/~1search/get/responses/401"
+        "422":
+          $ref: "#/paths/~1search/get/responses/422"
+        default:
+          $ref: "#/paths/~1organisation/get/responses/default"
+    put:
+      tags:
+        - TeachingGroup
+        - TeachingGroupSingle
+      summary: Update a single TeachingGroup
+      description: <p>Update a particular TeachingGroup, which can have multiple staff
+        assigned in a variety of roles (via <a
+        href="#tag/StaffTeachingGroupAssignment">StaffTeachingGroupAssignment</a>),  may
+        be assigned students from multiple year levels (via <a
+        href="#tag/StudentTeachingGroupEnrolment">StudentTeachingGroupEnrolment</a>),
+        and may be taught multiple <a
+        href="#tag/ProviderCourse">ProviderCourses</a>.</p>
+      operationId: updateTeachingGroup
+      security:
+        - sifDataObject:
+            - SMS
+      parameters:
+        - $ref: "#/paths/~1search/get/parameters/6"
+        - $ref: "#/paths/~1staffpersonal/post/parameters/2"
+        - $ref: "#/paths/~1teachinggroup~1%7BTeachingGroupRefId%7D~1staffteachinggr\
+            oupassignment/get/parameters/12"
+      requestBody:
+        description: CRUD operation on TeachingGroup
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                TeachingGroup:
+                  $ref: jsonSchema.NZ.create.yaml#/properties/TeachingGroup
+            example:
+              $ref: "#/paths/~1teachinggroup~1%7BTeachingGroupRefId%7D/get/response\
+                s/200/content/application~1json/example"
+          application/xml:
+            schema:
+              type: object
+              properties:
+                TeachingGroup:
+                  $ref: jsonSchema.NZ.create.yaml#/properties/TeachingGroup
+            example:
+              $ref: "#/paths/~1teachinggroup~1%7BTeachingGroupRefId%7D/get/response\
+                s/200/content/application~1xml/example"
+      responses:
+        "200":
+          description: Patch successful; returns patched object
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  TeachingGroup:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/TeachingGroup
+              example:
+                $ref: "#/paths/~1teachinggroup~1%7BTeachingGroupRefId%7D/get/respon\
+                  ses/200/content/application~1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  TeachingGroup:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/TeachingGroup
+              example:
+                $ref: "#/paths/~1teachinggroup~1%7BTeachingGroupRefId%7D/get/respon\
+                  ses/200/content/application~1xml/example"
+        "401":
+          $ref: "#/paths/~1search/get/responses/401"
+        "422":
+          $ref: "#/paths/~1search/get/responses/422"
+        default:
+          $ref: "#/paths/~1organisation~1%7BOrganisationRefId%7D/patch/responses/de\
+            fault"
+    patch:
+      tags:
+        - TeachingGroup
+        - TeachingGroupSingle
+      summary: Patch a single TeachingGroup
+      description: <p>Update one or more fields of a particular TeachingGroup, which can
+        have multiple staff assigned in a variety of roles (via <a
+        href="#tag/StaffTeachingGroupAssignment">StaffTeachingGroupAssignment</a>),  may
+        be assigned students from multiple year levels (via <a
+        href="#tag/StudentTeachingGroupEnrolment">StudentTeachingGroupEnrolment</a>),
+        and may be taught multiple <a
+        href="#tag/ProviderCourse">ProviderCourses</a>.</p>
+      operationId: patchTeachingGroup
+      security:
+        - sifDataObject:
+            - SMS
+      parameters:
+        - $ref: "#/paths/~1search/get/parameters/6"
+        - $ref: "#/paths/~1staffpersonal/post/parameters/2"
+        - $ref: "#/paths/~1teachinggroup~1%7BTeachingGroupRefId%7D~1staffteachinggr\
+            oupassignment/get/parameters/12"
+      requestBody:
+        description: CRUD operation on TeachingGroup
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                TeachingGroup:
+                  $ref: jsonSchema.NZ.update.yaml#/properties/TeachingGroup
+            example:
+              $ref: "#/paths/~1teachinggroup~1%7BTeachingGroupRefId%7D/get/response\
+                s/200/content/application~1json/example"
+          application/xml:
+            schema:
+              type: object
+              properties:
+                TeachingGroup:
+                  $ref: jsonSchema.NZ.update.yaml#/properties/TeachingGroup
+            example:
+              $ref: "#/paths/~1teachinggroup~1%7BTeachingGroupRefId%7D/get/response\
+                s/200/content/application~1xml/example"
+      responses:
+        "200":
+          description: Patch successful; returns patched object
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  TeachingGroup:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/TeachingGroup
+              example:
+                $ref: "#/paths/~1teachinggroup~1%7BTeachingGroupRefId%7D/get/respon\
+                  ses/200/content/application~1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  TeachingGroup:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/TeachingGroup
+              example:
+                $ref: "#/paths/~1teachinggroup~1%7BTeachingGroupRefId%7D/get/respon\
+                  ses/200/content/application~1xml/example"
+        "401":
+          $ref: "#/paths/~1search/get/responses/401"
+        "422":
+          $ref: "#/paths/~1search/get/responses/422"
+        default:
+          $ref: "#/paths/~1organisation~1%7BOrganisationRefId%7D/patch/responses/de\
+            fault"
+  "/staffpersonal/{StaffPersonalRefId}/teachinggroup":
+    get:
+      tags:
+        - TeachingGroup
+        - TeachingGroupSearch
+      summary: Retrieve TeachingGroups by Staff member
+      description: <p>Retrieve all available TeachingGroup where the given staff member has
+        been assigned a role (via <a
+        href="#tag/StaffTeachingGroupAssignment">StaffTeachingGroupAssignment</a>)</p>
+      operationId: getTeachingGroupsByStaff
+      security:
+        - sifDataObject:
+            - SMS
+      parameters:
+        - $ref: "#/paths/~1organisation/get/parameters/0"
+        - $ref: "#/paths/~1search/get/parameters/4"
+        - $ref: "#/paths/~1search/get/parameters/3"
+        - $ref: "#/paths/~1organisation/get/parameters/3"
+        - $ref: "#/paths/~1search/get/parameters/5"
+        - $ref: "#/paths/~1organisation/get/parameters/5"
+        - $ref: "#/paths/~1organisation/get/parameters/6"
+        - $ref: "#/paths/~1organisation/get/parameters/7"
+        - $ref: "#/paths/~1search/get/parameters/6"
+        - $ref: "#/paths/~1staffpersonal/post/parameters/2"
+        - $ref: "#/paths/~1staffassignment~1%7BStaffPersonalRefId%7D/get/parameters\
+            /12"
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  TeachingGroups:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/TeachingGroups
+              example:
+                $ref: "#/paths/~1teachinggroup/post/requestBody/content/application\
+                  ~1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  TeachingGroup:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/TeachingGroup
+              example:
+                $ref: "#/paths/~1teachinggroup/post/requestBody/content/application\
+                  ~1xml/example"
+        "401":
+          $ref: "#/paths/~1search/get/responses/401"
+        "422":
+          $ref: "#/paths/~1search/get/responses/422"
+        default:
+          $ref: "#/paths/~1organisation/get/responses/default"
+  "/studentpersonal/{StudentPersonalRefId}/teachinggroup":
+    get:
+      tags:
+        - TeachingGroup
+        - TeachingGroupSearch
+      summary: Retrieve TeachingGroups by Student
+      description: <p>Retrieve all available TeachingGroup where the given Student has been
+        enrolled  (via <a
+        href="#tag/StudentTeachingGroupEnrolment">StudentTeachingGroupEnrolment</a>)</p>
+      operationId: getTeachingGroupsByStudent
+      security:
+        - sifDataObject:
+            - SMS
+      parameters:
+        - $ref: "#/paths/~1organisation/get/parameters/0"
+        - $ref: "#/paths/~1search/get/parameters/4"
+        - $ref: "#/paths/~1search/get/parameters/3"
+        - $ref: "#/paths/~1organisation/get/parameters/3"
+        - $ref: "#/paths/~1search/get/parameters/5"
+        - $ref: "#/paths/~1organisation/get/parameters/5"
+        - $ref: "#/paths/~1organisation/get/parameters/6"
+        - $ref: "#/paths/~1organisation/get/parameters/7"
+        - $ref: "#/paths/~1search/get/parameters/6"
+        - $ref: "#/paths/~1staffpersonal/post/parameters/2"
+        - name: StudentPersonalRefId
+          in: path
+          required: true
+          description: System RefId of the student.
+          schema:
+            type: string
+          example: 979fbe68-4cfd-41c1-a98d-40e5601c7d98
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  TeachingGroups:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/TeachingGroups
+              example:
+                $ref: "#/paths/~1teachinggroup/post/requestBody/content/application\
+                  ~1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  TeachingGroup:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/TeachingGroup
+              example:
+                $ref: "#/paths/~1teachinggroup/post/requestBody/content/application\
+                  ~1xml/example"
+        "401":
+          $ref: "#/paths/~1search/get/responses/401"
+        "422":
+          $ref: "#/paths/~1search/get/responses/422"
+        default:
+          $ref: "#/paths/~1organisation/get/responses/default"
+  /academicdepartment:
+    post:
+      tags:
+        - AcademicDepartment
+        - AcademicDepartmentBulk
+      summary: Create one or more AcademicDepartments
+      description: Bulk operation to create one or more AcademicDepartments which group <a
+        href="#tagProviderCourse">ProviderCourses</a> and  <a
+        href="#tagTeachingGroup">TeachingGroups</a> according to
+        SubjectArea.</p>
+      operationId: createAcademicDepartments
+      parameters:
+        - $ref: "#/paths/~1organisation/post/parameters/0"
+        - $ref: "#/paths/~1staffpersonal/post/parameters/2"
+        - $ref: "#/paths/~1search/get/parameters/6"
+      requestBody:
+        description: CRUD operation on AcademicDepartment
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                AcademicDepartments:
+                  $ref: jsonSchema.NZ.create.yaml#/properties/AcademicDepartments
+            example:
+              AcademicDepartments:
+                AcademicDepartment:
+                  - AcademicDepartmentRefId: 2ffb63b4-cfef-4820-8501-e7d1e54555cb
+                    Name: Science Department
+                    Provider:
+                      RefId: "9651"
+                    StaffList:
+                      StaffMember:
+                        - RefId: 44fb63b4-cfef-4820-8501-e7d1e54555cb
+                          Name: Bobby Test
+                          Role: "1205"
+          application/xml:
+            schema:
+              type: object
+              properties:
+                AcademicDepartments:
+                  $ref: jsonSchema.NZ.create.yaml#/properties/AcademicDepartments
+            example: >-
+              <AcademicDepartments>
+                <AcademicDepartment>
+                  </AcademicDepartmentRefId>2ffb63b4-cfef-4820-8501-e7d1e54555cb</AcademicDepartmentRefId>
+                  </Name>Science Department</Name>
+                  <Provider>
+                    </RefId>9561</RefId>
+                  </Provider>
+                  <StaffList>
+                    <StaffMember>
+                      </RefId>44fb63b4-cfef-4820-8501-e7d1e54555cb</RefId>
+                      </Name>Bobby Test</Name>
+                      <Role>1205</Role>
+                    </StaffMember>
+                  </StaffList>
+                </AcademicDepartment>
+              </AcademicDepartments>
+      responses:
+        "200":
+          description: Create successful; returns created objects
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  AcademicDepartments:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/AcademicDepartments
+              example:
+                $ref: "#/paths/~1academicdepartment/post/requestBody/content/applic\
+                  ation~1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  AcademicDepartments:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/AcademicDepartments
+              example:
+                $ref: "#/paths/~1academicdepartment/post/requestBody/content/applic\
+                  ation~1xml/example"
+        "401":
+          $ref: "#/paths/~1search/get/responses/401"
+        "422":
+          $ref: "#/paths/~1search/get/responses/422"
+        default:
+          description: Some objects created, some creates failed
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  anyOf:
+                    - type: object
+                      title: Error
+                      properties:
+                        Error:
+                          $ref: "#/paths/~1organisation/post/responses/default/cont\
+                            ent/application~1json/schema/items/anyOf/0/properti\
+                            es/Error"
+                    - type: object
+                      title: AcademicDepartment
+                      properties:
+                        AcademicDepartment:
+                          $ref: jsonSchema.NZ.create.yaml#/properties/AcademicDepartment
+              example:
+                - AcademicDepartment:
+                    AcademicDepartmentRefId: 2ffb63b4-cfef-4820-8501-e7d1e54555cb
+                    Name: Science Department
+                    Provider:
+                      RefId: "9651"
+                    StaffList:
+                      StaffMember:
+                        - RefId: 44fb63b4-cfef-4820-8501-e7d1e54555cb
+                          Name: Bobby Test
+                          Role: "1205"
+                - Error:
+                    error: 1009
+                    when: 2020-07-16T20:00:46.000Z
+                    errorstr: "Bad field: PersonInfo-Name-FamilyName: missing required
+                      field PersonInfo-Name-FamilyName (LastName) 'None'"
+                    localId: ST-002
+                    refId: null
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  Response:
+                    type: array
+                    items:
+                      anyOf:
+                        - type: object
+                          title: Error
+                          properties:
+                            Error:
+                              $ref: "#/paths/~1organisation/post/responses/default/\
+                                content/application~1xml/schema/properties/Resp\
+                                onse/items/anyOf/0/properties/Error"
+                        - type: object
+                          title: AcademicDepartment
+                          properties:
+                            AcademicDepartment:
+                              $ref: jsonSchema.NZ.create.yaml#/properties/AcademicDepartment
+              example: >-
+                <Response>
+                  <AcademicDepartment>
+                    <AcademicDepartmentRefId>2ffb63b4-cfef-4820-8501-e7d1e54555cb</AcademicDepartmentRefId>
+                    <Name>Science Department</Name>
+                    <Provider>
+                      </RefId>9651</RefId>
+                    </Provider>
+                    <StaffList>
+                      <StaffMember>
+                        </RefId>44fb63b4-cfef-4820-8501-e7d1e54555cb</RefId>
+                        </Name>Bobby Test</Name>
+                      </StaffMember>
+                    </StaffList>
+                  </AcademicDepartment>
+                  <Error>
+                    <error>1009</error>
+                    <when>2020-07-16T20:00:46.000Z</when>
+                    <errorstr>Bad field: PersonInfo-Name-FamilyName: missing required field PersonInfo-Name-FamilyName (LastName) 'None'</errorstr>
+                    <localId>ST-002</localId>
+                    <refId/>
+                  </Error>      
+                </Response>
+    get:
+      tags:
+        - AcademicDepartment
+        - AcademicDepartmentBulk
+      summary: Retrieve all AcademicDepartments
+      description: Bulk operation to retrieve all available AcademicDepartments, within the
+        scope of the given Provider.  Each AcademicDepartment groups <a
+        href="#tagProviderCourse">ProviderCourses</a> and  <a
+        href="#tagTeachingGroup">TeachingGroups</a> according to
+        SubjectArea.</p>
+      operationId: getAcademicDepartments
+      parameters:
+        - $ref: "#/paths/~1organisation/get/parameters/0"
+        - $ref: "#/paths/~1search/get/parameters/4"
+        - $ref: "#/paths/~1search/get/parameters/3"
+        - $ref: "#/paths/~1organisation/get/parameters/3"
+        - $ref: "#/paths/~1search/get/parameters/5"
+        - $ref: "#/paths/~1organisation/get/parameters/5"
+        - $ref: "#/paths/~1organisation/get/parameters/6"
+        - $ref: "#/paths/~1organisation/get/parameters/7"
+        - $ref: "#/paths/~1staffpersonal/post/parameters/2"
+        - $ref: "#/paths/~1search/get/parameters/6"
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  AcademicDepartments:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/AcademicDepartments
+              example:
+                $ref: "#/paths/~1academicdepartment/post/requestBody/content/applic\
+                  ation~1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  AcademicDepartments:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/AcademicDepartments
+              example:
+                $ref: "#/paths/~1academicdepartment/post/requestBody/content/applic\
+                  ation~1xml/example"
+        "401":
+          $ref: "#/paths/~1search/get/responses/401"
+        "422":
+          $ref: "#/paths/~1search/get/responses/422"
+        default:
+          $ref: "#/paths/~1organisation/get/responses/default"
+    put:
+      tags:
+        - AcademicDepartment
+        - AcademicDepartmentBulk
+      summary: Update one or more AcademicDepartments
+      description: Bulk operation to update all available AcademicDepartments, within the
+        scope of the given Provider.  Each AcademicDepartment groups <a
+        href="#tagProviderCourse">ProviderCourses</a> and  <a
+        href="#tagTeachingGroup">TeachingGroups</a> according to
+        SubjectArea.</p>
+      operationId: updateAcademicDepartments
+      parameters:
+        - $ref: "#/paths/~1staffpersonal/post/parameters/2"
+        - $ref: "#/paths/~1search/get/parameters/6"
+      requestBody:
+        description: CRUD operation on AcademicDepartment
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                AcademicDepartments:
+                  $ref: jsonSchema.NZ.create.yaml#/properties/AcademicDepartments
+            example:
+              $ref: "#/paths/~1academicdepartment/post/requestBody/content/applicat\
+                ion~1json/example"
+          application/xml:
+            schema:
+              type: object
+              properties:
+                AcademicDepartments:
+                  $ref: jsonSchema.NZ.create.yaml#/properties/AcademicDepartments
+            example:
+              $ref: "#/paths/~1academicdepartment/post/requestBody/content/applicat\
+                ion~1xml/example"
+      responses:
+        "200":
+          description: Update successful; returns updated objects
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  AcademicDepartments:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/AcademicDepartments
+              example:
+                $ref: "#/paths/~1academicdepartment/post/requestBody/content/applic\
+                  ation~1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  AcademicDepartments:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/AcademicDepartments
+              example:
+                $ref: "#/paths/~1academicdepartment/post/requestBody/content/applic\
+                  ation~1xml/example"
+        "401":
+          $ref: "#/paths/~1search/get/responses/401"
+        "422":
+          $ref: "#/paths/~1search/get/responses/422"
+        default:
+          description: Some objects updated, some updates failed
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  anyOf:
+                    - type: object
+                      title: Error
+                      properties:
+                        Error:
+                          $ref: "#/paths/~1organisation/post/responses/default/cont\
+                            ent/application~1json/schema/items/anyOf/0/properti\
+                            es/Error"
+                    - type: object
+                      title: AcademicDepartment
+                      properties:
+                        AcademicDepartment:
+                          $ref: jsonSchema.NZ.create.yaml#/properties/AcademicDepartment
+              example:
+                $ref: "#/paths/~1academicdepartment/post/responses/default/content/\
+                  application~1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  Response:
+                    type: array
+                    items:
+                      anyOf:
+                        - type: object
+                          title: Error
+                          properties:
+                            Error:
+                              $ref: "#/paths/~1organisation/post/responses/default/\
+                                content/application~1xml/schema/properties/Resp\
+                                onse/items/anyOf/0/properties/Error"
+                        - type: object
+                          title: AcademicDepartment
+                          properties:
+                            AcademicDepartment:
+                              $ref: jsonSchema.NZ.create.yaml#/properties/AcademicDepartment
+              example:
+                $ref: "#/paths/~1academicdepartment/post/responses/default/content/\
+                  application~1xml/example"
+    patch:
+      tags:
+        - AcademicDepartment
+        - AcademicDepartmentBulk
+      summary: Patch one or more AcademicDepartments
+      description: Bulk operation to update one or more fields of one or more
+        AcademicDepartments, within the scope of the given Provider.  Each
+        AcademicDepartment groups <a
+        href="#tagProviderCourse">ProviderCourses</a> and  <a
+        href="#tagTeachingGroup">TeachingGroups</a> according to
+        SubjectArea.</p>
+      operationId: patchAcademicDepartments
+      parameters:
+        - $ref: "#/paths/~1staffpersonal/post/parameters/2"
+        - $ref: "#/paths/~1search/get/parameters/6"
+      requestBody:
+        description: CRUD operation on AcademicDepartment
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                AcademicDepartments:
+                  $ref: jsonSchema.NZ.update.yaml#/properties/AcademicDepartments
+            example:
+              $ref: "#/paths/~1academicdepartment/post/requestBody/content/applicat\
+                ion~1json/example"
+          application/xml:
+            schema:
+              type: object
+              properties:
+                AcademicDepartments:
+                  $ref: jsonSchema.NZ.update.yaml#/properties/AcademicDepartments
+            example:
+              $ref: "#/paths/~1academicdepartment/post/requestBody/content/applicat\
+                ion~1xml/example"
+      responses:
+        "200":
+          description: Patch successful; returns patched objects
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  AcademicDepartments:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/AcademicDepartments
+              example:
+                $ref: "#/paths/~1academicdepartment/post/requestBody/content/applic\
+                  ation~1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  AcademicDepartments:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/AcademicDepartments
+              example:
+                $ref: "#/paths/~1academicdepartment/post/requestBody/content/applic\
+                  ation~1xml/example"
+        "401":
+          $ref: "#/paths/~1search/get/responses/401"
+        "422":
+          $ref: "#/paths/~1search/get/responses/422"
+        default:
+          description: Some objects patched, some patches failed
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  anyOf:
+                    - type: object
+                      title: Error
+                      properties:
+                        Error:
+                          $ref: "#/paths/~1organisation/post/responses/default/cont\
+                            ent/application~1json/schema/items/anyOf/0/properti\
+                            es/Error"
+                    - type: object
+                      title: AcademicDepartment
+                      properties:
+                        AcademicDepartment:
+                          $ref: jsonSchema.NZ.create.yaml#/properties/AcademicDepartment
+              example:
+                $ref: "#/paths/~1academicdepartment/post/responses/default/content/\
+                  application~1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  Response:
+                    type: array
+                    items:
+                      anyOf:
+                        - type: object
+                          title: Error
+                          properties:
+                            Error:
+                              $ref: "#/paths/~1organisation/post/responses/default/\
+                                content/application~1xml/schema/properties/Resp\
+                                onse/items/anyOf/0/properties/Error"
+                        - type: object
+                          title: AcademicDepartment
+                          properties:
+                            AcademicDepartment:
+                              $ref: jsonSchema.NZ.create.yaml#/properties/AcademicDepartment
+              example:
+                $ref: "#/paths/~1academicdepartment/post/responses/default/content/\
+                  application~1xml/example"
+  "/academicdepartment/{AcademicDepartmentRefId}":
+    get:
+      tags:
+        - AcademicDepartment
+        - AcademicDepartmentSingle
+      summary: Retrieve a single AcademicDepartment
+      description: Retrieve a particular AcademicDepartment which groups <a
+        href="#tagProviderCourse">ProviderCourses</a> and  <a
+        href="#tagTeachingGroup">TeachingGroups</a> according to
+        SubjectArea.</p>
+      operationId: getAcademicDepartment
+      parameters:
+        - $ref: "#/paths/~1organisation/get/parameters/0"
+        - $ref: "#/paths/~1search/get/parameters/4"
+        - $ref: "#/paths/~1search/get/parameters/3"
+        - $ref: "#/paths/~1organisation/get/parameters/3"
+        - $ref: "#/paths/~1search/get/parameters/5"
+        - $ref: "#/paths/~1organisation/get/parameters/5"
+        - $ref: "#/paths/~1organisation/get/parameters/6"
+        - $ref: "#/paths/~1organisation/get/parameters/7"
+        - $ref: "#/paths/~1staffpersonal/post/parameters/2"
+        - $ref: "#/paths/~1search/get/parameters/6"
+        - name: AcademicDepartmentRefId
+          in: path
+          description: <p>The ID (GUID) assigned to uniquely identify this
+            AcademicDepartment.</p>
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  AcademicDepartment:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/AcademicDepartment
+              example:
+                AcademicDepartment:
+                  AcademicDepartmentRefId: 2ffb63b4-cfef-4820-8501-e7d1e54555cb
+                  Name: Science Department
+                  Provider:
+                    RefId: "9651"
+                  StaffList:
+                    StaffMember:
+                      - RefId: 44fb63b4-cfef-4820-8501-e7d1e54555cb
+                        Name: Bobby Test
+                        Role: "1205"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  AcademicDepartment:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/AcademicDepartment
+              example: >-
+                <AcademicDepartment>
+                  </AcademicDepartmentRefId>2ffb63b4-cfef-4820-8501-e7d1e54555cb</AcademicDepartmentRefId>
+                  </Name>Science Department</Name>
+                  <Provider>
+                    </RefId>9651</RefId>
+                  </Provider>
+                  <StaffList>
+                    <StaffMember>
+                      </RefId>44fb63b4-cfef-4820-8501-e7d1e54555cb</RefId>
+                      </Name>Bobby Test</Name>
+                      <Role>1205</Role>
+                    </StaffMember>
+                  </StaffList>
+                </AcademicDepartment>
+        "401":
+          $ref: "#/paths/~1search/get/responses/401"
+        "422":
+          $ref: "#/paths/~1search/get/responses/422"
+        default:
+          $ref: "#/paths/~1organisation/get/responses/default"
+    put:
+      tags:
+        - AcademicDepartment
+        - AcademicDepartmentSingle
+      summary: Update a single AcademicDepartment
+      description: Update a particular AcademicDepartment which groups <a
+        href="#tagProviderCourse">ProviderCourses</a> and  <a
+        href="#tagTeachingGroup">TeachingGroups</a> according to
+        SubjectArea.</p>
+      operationId: updateAcademicDepartment
+      parameters:
+        - $ref: "#/paths/~1staffpersonal/post/parameters/2"
+        - $ref: "#/paths/~1search/get/parameters/6"
+        - name: AcademicDepartmentRefId
+          in: path
+          description: <p>The ID (GUID) assigned to uniquely identify this
+            AcademicDepartment.</p>
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: CRUD operation on AcademicDepartment
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                AcademicDepartment:
+                  $ref: jsonSchema.NZ.create.yaml#/properties/AcademicDepartment
+            example:
+              $ref: "#/paths/~1academicdepartment~1%7BAcademicDepartmentRefId%7D/ge\
+                t/responses/200/content/application~1json/example"
+          application/xml:
+            schema:
+              type: object
+              properties:
+                AcademicDepartment:
+                  $ref: jsonSchema.NZ.create.yaml#/properties/AcademicDepartment
+            example:
+              $ref: "#/paths/~1academicdepartment~1%7BAcademicDepartmentRefId%7D/ge\
+                t/responses/200/content/application~1xml/example"
+      responses:
+        "200":
+          description: Update successful; returns updated object
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  AcademicDepartment:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/AcademicDepartment
+              example:
+                $ref: "#/paths/~1academicdepartment~1%7BAcademicDepartmentRefId%7D/\
+                  get/responses/200/content/application~1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  AcademicDepartment:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/AcademicDepartment
+              example:
+                $ref: "#/paths/~1academicdepartment~1%7BAcademicDepartmentRefId%7D/\
+                  get/responses/200/content/application~1xml/example"
+        "401":
+          $ref: "#/paths/~1search/get/responses/401"
+        "422":
+          $ref: "#/paths/~1search/get/responses/422"
+        default:
+          $ref: "#/paths/~1organisation~1%7BOrganisationRefId%7D/put/responses/defa\
+            ult"
+    patch:
+      tags:
+        - AcademicDepartment
+        - AcademicDepartmentSingle
+      summary: Patch a single AcademicDepartment
+      description: Update one or more fields of a particular AcademicDepartment which
+        groups <a href="#tagProviderCourse">ProviderCourses</a> and  <a
+        href="#tagTeachingGroup">TeachingGroups</a> according to
+        SubjectArea.</p>
+      operationId: patchAcademicDepartment
+      parameters:
+        - $ref: "#/paths/~1staffpersonal/post/parameters/2"
+        - $ref: "#/paths/~1search/get/parameters/6"
+        - name: AcademicDepartmentRefId
+          in: path
+          description: <p>The ID (GUID) assigned to uniquely identify this
+            AcademicDepartment.</p>
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: CRUD operation on AcademicDepartment
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                AcademicDepartment:
+                  $ref: jsonSchema.NZ.update.yaml#/properties/AcademicDepartment
+            example:
+              $ref: "#/paths/~1academicdepartment~1%7BAcademicDepartmentRefId%7D/ge\
+                t/responses/200/content/application~1json/example"
+          application/xml:
+            schema:
+              type: object
+              properties:
+                AcademicDepartment:
+                  $ref: jsonSchema.NZ.update.yaml#/properties/AcademicDepartment
+            example:
+              $ref: "#/paths/~1academicdepartment~1%7BAcademicDepartmentRefId%7D/ge\
+                t/responses/200/content/application~1xml/example"
+      responses:
+        "200":
+          description: Patch successful; returns patched object
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  AcademicDepartment:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/AcademicDepartment
+              example:
+                $ref: "#/paths/~1academicdepartment~1%7BAcademicDepartmentRefId%7D/\
+                  get/responses/200/content/application~1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  AcademicDepartment:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/AcademicDepartment
+              example:
+                $ref: "#/paths/~1academicdepartment~1%7BAcademicDepartmentRefId%7D/\
+                  get/responses/200/content/application~1xml/example"
+        "401":
+          $ref: "#/paths/~1search/get/responses/401"
+        "422":
+          $ref: "#/paths/~1search/get/responses/422"
+        default:
+          $ref: "#/paths/~1organisation~1%7BOrganisationRefId%7D/patch/responses/de\
+            fault"
+  /providercourse:
+    post:
+      tags:
+        - ProviderCourse
+        - ProviderCourseBulk
+      summary: Create one or more ProviderCourses
+      description: <p>Bulk operation to create one or more provider defined Courses that
+        Students enrol in,  may be assessed for, and achieve passes in.</p>
+      operationId: createProviderCourses
+      parameters:
+        - $ref: "#/paths/~1organisation/post/parameters/0"
+        - $ref: "#/paths/~1search/get/parameters/6"
+        - $ref: "#/paths/~1staffpersonal/post/parameters/2"
+      requestBody:
+        description: CRUD operation on ProviderCourse
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                ProviderCourses:
+                  $ref: jsonSchema.NZ.create.yaml#/properties/ProviderCourses
+            example:
+              ProviderCourses:
+                ProviderCourse:
+                  - ProviderCourseRefId: 9d75101a-8c3d-00aa-001a-0000a2e35b35
+                    ProviderCourseLocalId: 12CHEM
+                    Provider:
+                      RefId: "9651"
+                    Curriculum: NZC
+                    SubjectAreaList:
+                      SubjectArea:
+                        - CHEM
+                    YearLevelList:
+                      YearLevel:
+                        - 12
+                    Title: Year 12 Chemistry
+                    Description: Organic & Inorganic Chemistry for NCEA Level 2
+                    Duration: 35
+                    Credits: 11
+                    LearningStandardList:
+                      LearningStandardRefId:
+                        - NC-91165-2
+                        - NC-91166-2
+                        - NC-91167-2
+          application/xml:
+            schema:
+              type: object
+              properties:
+                ProviderCourses:
+                  $ref: jsonSchema.NZ.create.yaml#/properties/ProviderCourses
+            example: >-
+              <ProviderCourses>
+                <ProviderCourse>
+                  </ProviderCourseRefId>9d75101a-8c3d-00aa-001a-0000a2e35b35</ProviderCourseRefId>
+                  </ProviderCourseLocalId>12CHEM</ProviderCourseLocalId>
+                  <Provider>
+                    </RefId>101a8c3d-00aa-001a-0000-a2e35b359d75</RefId>
+                    </LocalId>208</LocalId>
+                  </Provider>
+                  </Curriculum>NZC</Curriculum>
+                  <SubjectAreaList>
+                    </SubjectArea>CHEM</SubjectArea>
+                  </SubjectAreaList>
+                  <YearLevelList>
+                    </YearLevel>12</YearLevel>
+                  </YearLevelList>
+                  </Title>Year 12 Chemistry</Title>
+                  </Description>Organic & Inorganic Chemistry for NCEA Level 2</Description>
+                  </Duration>35</Duration>
+                  </Credits>11</Credits>
+                  <LanguageOfInstructionList>
+                    <Language>
+                      </Code>NZS01112</Code>
+                      </Level>1</Level>
+                    </Language>
+                  </LanguageOfInstructionList>
+                  <LearningStandardList>
+                    <LearningStandardList>
+                      <LearningStandardRefId>NC-91165-2</LocalId>
+                      <LearningStandardRefId>NC-91166-2</LocalId>
+                      <LearningStandardRefId>MC-91167-2</LocalId>
+                    </LearningStandardList>
+                  </LearningStandardList>
+                </ProviderCourse>
+              </ProviderCourses>
+      responses:
+        "200":
+          description: All objects created; returns created objects
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ProviderCourses:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/ProviderCourses
+              example:
+                $ref: "#/paths/~1providercourse/post/requestBody/content/applicatio\
+                  n~1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  ProviderCourses:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/ProviderCourses
+              example:
+                $ref: "#/paths/~1providercourse/post/requestBody/content/applicatio\
+                  n~1xml/example"
+        "401":
+          $ref: "#/paths/~1search/get/responses/401"
+        "422":
+          $ref: "#/paths/~1search/get/responses/422"
+        default:
+          description: Some objects created, some creates failed
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  anyOf:
+                    - type: object
+                      title: Error
+                      properties:
+                        Error:
+                          $ref: "#/paths/~1organisation/post/responses/default/cont\
+                            ent/application~1json/schema/items/anyOf/0/properti\
+                            es/Error"
+                    - type: object
+                      title: ProviderCourse
+                      properties:
+                        ProviderCourse:
+                          $ref: jsonSchema.NZ.create.yaml#/properties/ProviderCourse
+              example:
+                - ProviderCourse:
+                    ProviderCourseRefId: 9d75101a-8c3d-00aa-001a-0000a2e35b35
+                    ProviderCourseLocalId: 12CHEM
+                    Provider:
+                      RefId: "9651"
+                    Curriculum: NZC
+                    SubjectAreaList:
+                      SubjectArea:
+                        - CHEM
+                    YearLevelList:
+                      YearLevel:
+                        - 12
+                    Title: Year 12 Chemistry
+                    Description: Organic & Inorganic Chemistry for NCEA Level 2
+                    Duration: 35
+                    Credits: 11
+                    LearningStandardList:
+                      LearningStandardRefId:
+                        - NC-91165-2
+                        - NC-91166-2
+                        - NC-91167-2
+                - Error:
+                    error: 1009
+                    when: 2020-07-16T20:00:46.000Z
+                    errorstr: "Bad field: PersonInfo-Name-FamilyName: missing required
+                      field PersonInfo-Name-FamilyName (LastName) 'None'"
+                    localId: ST-002
+                    refId: null
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  Response:
+                    type: array
+                    items:
+                      anyOf:
+                        - type: object
+                          title: Error
+                          properties:
+                            Error:
+                              $ref: "#/paths/~1organisation/post/responses/default/\
+                                content/application~1xml/schema/properties/Resp\
+                                onse/items/anyOf/0/properties/Error"
+                        - type: object
+                          title: ProviderCourse
+                          properties:
+                            ProviderCourse:
+                              $ref: jsonSchema.NZ.create.yaml#/properties/ProviderCourse
+              example: >-
+                <Response>
+                  <ProviderCourse>
+                    </ProviderCourseRefId>9d75101a-8c3d-00aa-001a-0000a2e35b35</ProviderCourseRefId>
+                    </ProviderCourseLocalId>12CHEM</ProviderCourseLocalId>
+                    <Provider>
+                      </RefId>101a8c3d-00aa-001a-0000-a2e35b359d75</RefId>
+                      </LocalId>208</LocalId>
+                    </Provider>
+                    </Curriculum>NZC</Curriculum>
+                    <SubjectAreaList>
+                      </SubjectArea>CHEM</SubjectArea>
+                    </SubjectAreaList>
+                    <YearLevelList>
+                      </YearLevel>12</YearLevel>
+                    </YearLevelList>
+                    </Title>Year 12 Chemistry</Title>
+                    </Description>Organic & Inorganic Chemistry for NCEA Level 2</Description>
+                    </Duration>35</Duration>
+                    </Credits>11</Credits>
+                    <LanguageOfInstructionList>
+                      <Language>
+                        </Code>NZS01112</Code>
+                        </Level>1</Level>
+                      </Language>
+                    </LanguageOfInstructionList>
+                    <LearningStandardList>
+                      <LearningStandardList>
+                        <LearningStandardRefId>NC-91165-2</LocalId>
+                        <LearningStandardRefId>NC-91166-2</LocalId>
+                        <LearningStandardRefId>MC-91167-2</LocalId>
+                      </LearningStandardList>
+                    </LearningStandardList>
+                  </ProviderCourse>  
+                  <Error>
+                    <error>1009</error>
+                    <when>2020-07-16T20:00:46.000Z</when>
+                    <errorstr>Bad field: PersonInfo-Name-FamilyName: missing required field PersonInfo-Name-FamilyName (LastName) 'None'</errorstr>
+                    <localId>ST-002</localId>
+                    <refId/>
+                  </Error>      
+                </Response>
+    get:
+      tags:
+        - ProviderCourse
+        - ProviderCourseBulk
+      summary: Retrieve one or more ProviderCourses
+      description: "<p>Bulk operation to retrieve one or more provider defined Courses that
+        Students enrol in,  may be assessed for, and achieve passes in.</p>    "
+      operationId: getProviderCourses
+      parameters:
+        - $ref: "#/paths/~1organisation/get/parameters/0"
+        - $ref: "#/paths/~1search/get/parameters/4"
+        - $ref: "#/paths/~1search/get/parameters/3"
+        - $ref: "#/paths/~1organisation/get/parameters/3"
+        - $ref: "#/paths/~1search/get/parameters/5"
+        - $ref: "#/paths/~1organisation/get/parameters/5"
+        - $ref: "#/paths/~1organisation/get/parameters/6"
+        - $ref: "#/paths/~1organisation/get/parameters/7"
+        - $ref: "#/paths/~1search/get/parameters/6"
+        - $ref: "#/paths/~1staffpersonal/post/parameters/2"
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ProviderCourses:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/ProviderCourses
+              example:
+                $ref: "#/paths/~1providercourse/post/requestBody/content/applicatio\
+                  n~1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  ProviderCourses:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/ProviderCourses
+              example:
+                $ref: "#/paths/~1providercourse/post/requestBody/content/applicatio\
+                  n~1xml/example"
+        "401":
+          $ref: "#/paths/~1search/get/responses/401"
+        "422":
+          $ref: "#/paths/~1search/get/responses/422"
+        default:
+          $ref: "#/paths/~1organisation/get/responses/default"
+    put:
+      tags:
+        - ProviderCourse
+        - ProviderCourseBulk
+      summary: Update one or more ProviderCourses
+      description: "<p>Bulk operation to update one or more provider defined Courses that
+        Students enrol in,  may be assessed for, and achieve passes in.</p>    "
+      operationId: updateProviderCourses
+      parameters:
+        - $ref: "#/paths/~1search/get/parameters/6"
+        - $ref: "#/paths/~1staffpersonal/post/parameters/2"
+      requestBody:
+        description: CRUD operation on ProviderCourse
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                ProviderCourses:
+                  $ref: jsonSchema.NZ.create.yaml#/properties/ProviderCourses
+            example:
+              $ref: "#/paths/~1providercourse/post/requestBody/content/application~\
+                1json/example"
+          application/xml:
+            schema:
+              type: object
+              properties:
+                ProviderCourses:
+                  $ref: jsonSchema.NZ.create.yaml#/properties/ProviderCourses
+            example:
+              $ref: "#/paths/~1providercourse/post/requestBody/content/application~\
+                1xml/example"
+      responses:
+        "200":
+          description: All objects updated; returns updated objects
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ProviderCourses:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/ProviderCourses
+              example:
+                $ref: "#/paths/~1providercourse/post/requestBody/content/applicatio\
+                  n~1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  ProviderCourses:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/ProviderCourses
+              example:
+                $ref: "#/paths/~1providercourse/post/requestBody/content/applicatio\
+                  n~1xml/example"
+        "401":
+          $ref: "#/paths/~1search/get/responses/401"
+        "422":
+          $ref: "#/paths/~1search/get/responses/422"
+        default:
+          description: Some objects updated, some updates failed
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  anyOf:
+                    - type: object
+                      title: Error
+                      properties:
+                        Error:
+                          $ref: "#/paths/~1organisation/post/responses/default/cont\
+                            ent/application~1json/schema/items/anyOf/0/properti\
+                            es/Error"
+                    - type: object
+                      title: ProviderCourse
+                      properties:
+                        ProviderCourse:
+                          $ref: jsonSchema.NZ.create.yaml#/properties/ProviderCourse
+              example:
+                $ref: "#/paths/~1providercourse/post/responses/default/content/appl\
+                  ication~1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  Response:
+                    type: array
+                    items:
+                      anyOf:
+                        - type: object
+                          title: Error
+                          properties:
+                            Error:
+                              $ref: "#/paths/~1organisation/post/responses/default/\
+                                content/application~1xml/schema/properties/Resp\
+                                onse/items/anyOf/0/properties/Error"
+                        - type: object
+                          title: ProviderCourse
+                          properties:
+                            ProviderCourse:
+                              $ref: jsonSchema.NZ.create.yaml#/properties/ProviderCourse
+              example:
+                $ref: "#/paths/~1providercourse/post/responses/default/content/appl\
+                  ication~1xml/example"
+    patch:
+      tags:
+        - ProviderCourse
+        - ProviderCourseBulk
+      summary: Patch one or more ProviderCourses
+      description: <p>Bulk operation to update one or more fields of one or more provider
+        defined Courses that Students enrol in, may be assessed for, and achieve
+        passes in.</p>
+      operationId: patchProviderCourses
+      parameters:
+        - $ref: "#/paths/~1search/get/parameters/6"
+        - $ref: "#/paths/~1staffpersonal/post/parameters/2"
+      requestBody:
+        description: CRUD operation on ProviderCourse
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                ProviderCourses:
+                  $ref: jsonSchema.NZ.update.yaml#/properties/ProviderCourses
+            example:
+              $ref: "#/paths/~1providercourse/post/requestBody/content/application~\
+                1json/example"
+          application/xml:
+            schema:
+              type: object
+              properties:
+                ProviderCourses:
+                  $ref: jsonSchema.NZ.update.yaml#/properties/ProviderCourses
+            example:
+              $ref: "#/paths/~1providercourse/post/requestBody/content/application~\
+                1xml/example"
+      responses:
+        "200":
+          description: All objects patched; returns patched objects
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ProviderCourses:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/ProviderCourses
+              example:
+                $ref: "#/paths/~1providercourse/post/requestBody/content/applicatio\
+                  n~1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  ProviderCourses:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/ProviderCourses
+              example:
+                $ref: "#/paths/~1providercourse/post/requestBody/content/applicatio\
+                  n~1xml/example"
+        "401":
+          $ref: "#/paths/~1search/get/responses/401"
+        "422":
+          $ref: "#/paths/~1search/get/responses/422"
+        default:
+          description: Some objects patched, some patches failed
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  anyOf:
+                    - type: object
+                      title: Error
+                      properties:
+                        Error:
+                          $ref: "#/paths/~1organisation/post/responses/default/cont\
+                            ent/application~1json/schema/items/anyOf/0/properti\
+                            es/Error"
+                    - type: object
+                      title: ProviderCourse
+                      properties:
+                        ProviderCourse:
+                          $ref: jsonSchema.NZ.create.yaml#/properties/ProviderCourse
+              example:
+                $ref: "#/paths/~1providercourse/post/responses/default/content/appl\
+                  ication~1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  Response:
+                    type: array
+                    items:
+                      anyOf:
+                        - type: object
+                          title: Error
+                          properties:
+                            Error:
+                              $ref: "#/paths/~1organisation/post/responses/default/\
+                                content/application~1xml/schema/properties/Resp\
+                                onse/items/anyOf/0/properties/Error"
+                        - type: object
+                          title: ProviderCourse
+                          properties:
+                            ProviderCourse:
+                              $ref: jsonSchema.NZ.create.yaml#/properties/ProviderCourse
+              example:
+                $ref: "#/paths/~1providercourse/post/responses/default/content/appl\
+                  ication~1xml/example"
+  "/providercourse/{ProviderCourseRefId}":
+    get:
+      tags:
+        - ProviderCourse
+        - ProviderCourseSingle
+      summary: Retrieve a single ProviderCourse
+      description: "<p>Retrieve a particular provider defined Course that Students enrol
+        in,  may be assessed for, and achieve passes in.</p>    "
+      operationId: getProviderCourse
+      parameters:
+        - $ref: "#/paths/~1organisation/get/parameters/0"
+        - $ref: "#/paths/~1search/get/parameters/4"
+        - $ref: "#/paths/~1search/get/parameters/3"
+        - $ref: "#/paths/~1organisation/get/parameters/3"
+        - $ref: "#/paths/~1search/get/parameters/5"
+        - $ref: "#/paths/~1organisation/get/parameters/5"
+        - $ref: "#/paths/~1organisation/get/parameters/6"
+        - $ref: "#/paths/~1organisation/get/parameters/7"
+        - $ref: "#/paths/~1staffpersonal/post/parameters/2"
+        - $ref: "#/paths/~1search/get/parameters/6"
+        - name: ProviderCourseRefId
+          in: path
+          description: <p>The ID (GUID) that uniquely identifies the Provider defined
+            Course.</p>
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ProviderCourse:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/ProviderCourse
+              example:
+                ProviderCourse:
+                  ProviderCourseRefId: 9d75101a-8c3d-00aa-001a-0000a2e35b35
+                  ProviderCourseLocalId: 12CHEM
+                  Provider:
+                    RefId: "9651"
+                  Curriculum: NZC
+                  SubjectAreaList:
+                    SubjectArea:
+                      - CHEM
+                  YearLevelList:
+                    YearLevel:
+                      - 12
+                  Title: Year 12 Chemistry
+                  Description: Organic & Inorganic Chemistry for NCEA Level 2
+                  Duration: 35
+                  Credits: 11
+                  LearningStandardList:
+                    LearningStandardRefId:
+                      - NC-91165-2
+                      - NC-91166-2
+                      - NC-91167-2
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  ProviderCourse:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/ProviderCourse
+              example: >-
+                <ProviderCourse>
+                  </ProviderCourseRefId>9d75101a-8c3d-00aa-001a-0000a2e35b35</ProviderCourseRefId>
+                  </ProviderCourseLocalId>12CHEM</ProviderCourseLocalId>
+                  <Provider>
+                    </RefId>101a8c3d-00aa-001a-0000-a2e35b359d75</RefId>
+                    </LocalId>208</LocalId>
+                  </Provider>
+                  </Curriculum>NZC</Curriculum>
+                  <SubjectAreaList>
+                    </SubjectArea>CHEM</SubjectArea>
+                  </SubjectAreaList>
+                  <YearLevelList>
+                    </YearLevel>12</YearLevel>
+                  </YearLevelList>
+                  </Title>Year 12 Chemistry</Title>
+                  </Description>Organic & Inorganic Chemistry for NCEA Level 2</Description>
+                  </Duration>35</Duration>
+                  </Credits>11</Credits>
+                  <LanguageOfInstructionList>
+                    <Language>
+                      </Code>NZS01112</Code>
+                      </Level>1</Level>
+                    </Language>
+                  </LanguageOfInstructionList>
+                  <LearningStandardList>
+                    <LearningStandardRefId>NC-91165-2</LocalId>
+                    <LearningStandardRefId>NC-91166-2</LocalId>
+                    <LearningStandardRefId>MC-91167-2</LocalId>
+                  </LearningStandardList>
+                </ProviderCourse>  
+        "401":
+          $ref: "#/paths/~1search/get/responses/401"
+        "422":
+          $ref: "#/paths/~1search/get/responses/422"
+        default:
+          $ref: "#/paths/~1organisation/get/responses/default"
+    put:
+      tags:
+        - ProviderCourse
+        - ProviderCourseSingle
+      summary: Update a single ProviderCourse
+      description: <p>Update one or more fields of a particular provider defined Course
+        that Students enrol in,  may be assessed for, and achieve passes in.</p>
+      operationId: updateProviderCourse
+      parameters:
+        - $ref: "#/paths/~1search/get/parameters/6"
+        - $ref: "#/paths/~1staffpersonal/post/parameters/2"
+        - name: ProviderCourseRefId
+          in: path
+          description: <p>The ID (GUID) that uniquely identifies the Provider defined
+            Course.</p>
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: CRUD operation on ProviderCourse
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                ProviderCourse:
+                  $ref: jsonSchema.NZ.create.yaml#/properties/ProviderCourse
+            example:
+              $ref: "#/paths/~1providercourse~1%7BProviderCourseRefId%7D/get/respon\
+                ses/200/content/application~1json/example"
+          application/xml:
+            schema:
+              type: object
+              properties:
+                ProviderCourse:
+                  $ref: jsonSchema.NZ.create.yaml#/properties/ProviderCourse
+            example:
+              $ref: "#/paths/~1providercourse~1%7BProviderCourseRefId%7D/get/respon\
+                ses/200/content/application~1xml/example"
+      responses:
+        "200":
+          description: Update successful; returns updated object
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ProviderCourse:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/ProviderCourse
+              example:
+                $ref: "#/paths/~1providercourse~1%7BProviderCourseRefId%7D/get/resp\
+                  onses/200/content/application~1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  ProviderCourse:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/ProviderCourse
+              example:
+                $ref: "#/paths/~1providercourse~1%7BProviderCourseRefId%7D/get/resp\
+                  onses/200/content/application~1xml/example"
+        "401":
+          $ref: "#/paths/~1search/get/responses/401"
+        "422":
+          $ref: "#/paths/~1search/get/responses/422"
+        default:
+          $ref: "#/paths/~1organisation~1%7BOrganisationRefId%7D/put/responses/defa\
+            ult"
+    patch:
+      tags:
+        - ProviderCourse
+        - ProviderCourseSingle
+      summary: Patch a single ProviderCourse
+      description: <p>Update one or more fields of a particular provider defined Course
+        that Students enrol in,  may be assessed for, and achieve passes in.</p>
+      operationId: patchProviderCourse
+      parameters:
+        - $ref: "#/paths/~1search/get/parameters/6"
+        - $ref: "#/paths/~1staffpersonal/post/parameters/2"
+        - name: ProviderCourseRefId
+          in: path
+          description: <p>The ID (GUID) that uniquely identifies the Provider defined
+            Course.</p>
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: CRUD operation on ProviderCourse
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                ProviderCourse:
+                  $ref: jsonSchema.NZ.update.yaml#/properties/ProviderCourse
+            example:
+              $ref: "#/paths/~1providercourse~1%7BProviderCourseRefId%7D/get/respon\
+                ses/200/content/application~1json/example"
+          application/xml:
+            schema:
+              type: object
+              properties:
+                ProviderCourse:
+                  $ref: jsonSchema.NZ.update.yaml#/properties/ProviderCourse
+            example:
+              $ref: "#/paths/~1providercourse~1%7BProviderCourseRefId%7D/get/respon\
+                ses/200/content/application~1xml/example"
+      responses:
+        "200":
+          description: Patch successful; returns patched object
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ProviderCourse:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/ProviderCourse
+              example:
+                $ref: "#/paths/~1providercourse~1%7BProviderCourseRefId%7D/get/resp\
+                  onses/200/content/application~1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  ProviderCourse:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/ProviderCourse
+              example:
+                $ref: "#/paths/~1providercourse~1%7BProviderCourseRefId%7D/get/resp\
+                  onses/200/content/application~1xml/example"
+        "401":
+          $ref: "#/paths/~1search/get/responses/401"
+        "422":
+          $ref: "#/paths/~1search/get/responses/422"
+        default:
+          $ref: "#/paths/~1organisation~1%7BOrganisationRefId%7D/patch/responses/de\
+            fault"
+components:
+  securitySchemes:
+    sifDataObject:
+      type: oauth2
+      description: OAuth 2.0 authentication is applied to all SIF data objects. Scope
+        provided in the  JWT access token will be verified against Te Rito user
+        account role, that is separately provisioned.
+      flows:
+        clientCredentials:
+          tokenUrl: https://login.microsoftonline.com/6418b52e-37db-4261-bcf7-d64c4b0a59f5/oauth2/v2.0/token
+          scopes:
+            FIRST: 'Authorised as FIRST integration hub, able to maintain <a
+              href="#tag/Organisation">Organisation</a> and  <a
+              href="#tag/OrganisationRelationship">OrganisationRelationship</a>.
+              SIF role # <code>2501</code>'
+            SUPS: 'Authorised as Secondary User Provisioning System (SUPS)
+              integration hub, able to maintain <a
+              href="#tag/StaffPersonal">StaffPersonal</a> and  <a
+              href="#tag/StaffAssignment">StaffAssignment</a>. SIF role #
+              <code>2502</code>'
+            NZQA: 'Authorised client able to maintain <a
+              href="#tag/LearningStandard">LearningStandard</a> and  <a
+              href="#tag/Credential">Credential</a>. SIF role #
+              <code>2503</code>'
+            LSR: 'Authorised client able to maintain <a
+              href="#tag/StudentLearningSupport">StudentLearningSupport</a>, <a
+              href="#tag/StudentLearningSupportResponse">StudentLearningSupportResponse</a>
+              and Learning Support need flavours of <a
+              href="#tag/WellbeingCharacteristic">WellbeingCharacteristic</a>.
+              SIF role # <code>2504</code>'
+            SMS: "Authorised as SMS Client on behalf of a particular provider
+              (School/ECE). SIF role # <code>2505</code>"
+            DEFERRED: Authorised to access the deferred APIs

--- a/filtered.yaml
+++ b/filtered.yaml
@@ -1,0 +1,1249 @@
+paths:
+  /academicdepartment:
+    post:
+      tags:
+        - AcademicDepartment
+        - AcademicDepartmentBulk
+      summary: Create one or more AcademicDepartments
+      description: Bulk operation to create one or more AcademicDepartments which group <a href="#tagProviderCourse">ProviderCourses</a> and  <a href="#tagTeachingGroup">TeachingGroups</a> according to SubjectArea.</p>
+      operationId: createAcademicDepartments
+      parameters:
+        - $ref: "#/paths/~1organisation/post/parameters/0"
+        - $ref: "#/paths/~1staffpersonal/post/parameters/2"
+        - $ref: "#/paths/~1search/get/parameters/6"
+      requestBody:
+        description: CRUD operation on AcademicDepartment
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                AcademicDepartments:
+                  $ref: jsonSchema.NZ.create.yaml#/properties/AcademicDepartments
+            example:
+              AcademicDepartments:
+                AcademicDepartment:
+                  - AcademicDepartmentRefId: 2ffb63b4-cfef-4820-8501-e7d1e54555cb
+                    Name: Science Department
+                    Provider:
+                      RefId: "9651"
+                    StaffList:
+                      StaffMember:
+                        - RefId: 44fb63b4-cfef-4820-8501-e7d1e54555cb
+                          Name: Bobby Test
+                          Role: "1205"
+          application/xml:
+            schema:
+              type: object
+              properties:
+                AcademicDepartments:
+                  $ref: jsonSchema.NZ.create.yaml#/properties/AcademicDepartments
+            example: >-
+              <AcademicDepartments>
+                <AcademicDepartment>
+                  </AcademicDepartmentRefId>2ffb63b4-cfef-4820-8501-e7d1e54555cb</AcademicDepartmentRefId>
+                  </Name>Science Department</Name>
+                  <Provider>
+                    </RefId>9561</RefId>
+                  </Provider>
+                  <StaffList>
+                    <StaffMember>
+                      </RefId>44fb63b4-cfef-4820-8501-e7d1e54555cb</RefId>
+                      </Name>Bobby Test</Name>
+                      <Role>1205</Role>
+                    </StaffMember>
+                  </StaffList>
+                </AcademicDepartment>
+              </AcademicDepartments>
+      responses:
+        "200":
+          description: Create successful; returns created objects
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  AcademicDepartments:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/AcademicDepartments
+              example:
+                $ref: "#/paths/~1academicdepartment/post/requestBody/content/application~1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  AcademicDepartments:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/AcademicDepartments
+              example:
+                $ref: "#/paths/~1academicdepartment/post/requestBody/content/application~1xml/example"
+        "401":
+          $ref: "#/paths/~1search/get/responses/401"
+        "422":
+          $ref: "#/paths/~1search/get/responses/422"
+        default:
+          description: Some objects created, some creates failed
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  anyOf:
+                    - type: object
+                      title: Error
+                      properties:
+                        Error:
+                          $ref: "#/paths/~1organisation/post/responses/default/content/application~1json/schema/items/anyOf/0/properties/Error"
+                    - type: object
+                      title: AcademicDepartment
+                      properties:
+                        AcademicDepartment:
+                          $ref: jsonSchema.NZ.create.yaml#/properties/AcademicDepartment
+              example:
+                - AcademicDepartment:
+                    AcademicDepartmentRefId: 2ffb63b4-cfef-4820-8501-e7d1e54555cb
+                    Name: Science Department
+                    Provider:
+                      RefId: "9651"
+                    StaffList:
+                      StaffMember:
+                        - RefId: 44fb63b4-cfef-4820-8501-e7d1e54555cb
+                          Name: Bobby Test
+                          Role: "1205"
+                - Error:
+                    error: 1009
+                    when: 2020-07-16T20:00:46.000Z
+                    errorstr: "Bad field: PersonInfo-Name-FamilyName: missing required field PersonInfo-Name-FamilyName (LastName) 'None'"
+                    localId: ST-002
+                    refId: null
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  Response:
+                    type: array
+                    items:
+                      anyOf:
+                        - type: object
+                          title: Error
+                          properties:
+                            Error:
+                              $ref: "#/paths/~1organisation/post/responses/default/content/application~1xml/schema/properties/Response/items/anyOf/0/properties/Error"
+                        - type: object
+                          title: AcademicDepartment
+                          properties:
+                            AcademicDepartment:
+                              $ref: jsonSchema.NZ.create.yaml#/properties/AcademicDepartment
+              example: >-
+                <Response>
+                  <AcademicDepartment>
+                    <AcademicDepartmentRefId>2ffb63b4-cfef-4820-8501-e7d1e54555cb</AcademicDepartmentRefId>
+                    <Name>Science Department</Name>
+                    <Provider>
+                      </RefId>9651</RefId>
+                    </Provider>
+                    <StaffList>
+                      <StaffMember>
+                        </RefId>44fb63b4-cfef-4820-8501-e7d1e54555cb</RefId>
+                        </Name>Bobby Test</Name>
+                      </StaffMember>
+                    </StaffList>
+                  </AcademicDepartment>
+                  <Error>
+                    <error>1009</error>
+                    <when>2020-07-16T20:00:46.000Z</when>
+                    <errorstr>Bad field: PersonInfo-Name-FamilyName: missing required field PersonInfo-Name-FamilyName (LastName) 'None'</errorstr>
+                    <localId>ST-002</localId>
+                    <refId/>
+                  </Error>      
+                </Response>
+    get:
+      tags:
+        - AcademicDepartment
+        - AcademicDepartmentBulk
+      summary: Retrieve all AcademicDepartments
+      description: Bulk operation to retrieve all available AcademicDepartments, within the scope of the given Provider.  Each AcademicDepartment groups <a href="#tagProviderCourse">ProviderCourses</a> and  <a href="#tagTeachingGroup">TeachingGroups</a> according to SubjectArea.</p>
+      operationId: getAcademicDepartments
+      parameters:
+        - $ref: "#/paths/~1organisation/get/parameters/0"
+        - $ref: "#/paths/~1search/get/parameters/4"
+        - $ref: "#/paths/~1search/get/parameters/3"
+        - $ref: "#/paths/~1organisation/get/parameters/3"
+        - $ref: "#/paths/~1search/get/parameters/5"
+        - $ref: "#/paths/~1organisation/get/parameters/5"
+        - $ref: "#/paths/~1organisation/get/parameters/6"
+        - $ref: "#/paths/~1organisation/get/parameters/7"
+        - $ref: "#/paths/~1staffpersonal/post/parameters/2"
+        - $ref: "#/paths/~1search/get/parameters/6"
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  AcademicDepartments:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/AcademicDepartments
+              example:
+                $ref: "#/paths/~1academicdepartment/post/requestBody/content/application~1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  AcademicDepartments:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/AcademicDepartments
+              example:
+                $ref: "#/paths/~1academicdepartment/post/requestBody/content/application~1xml/example"
+        "401":
+          $ref: "#/paths/~1search/get/responses/401"
+        "422":
+          $ref: "#/paths/~1search/get/responses/422"
+        default:
+          $ref: "#/paths/~1organisation/get/responses/default"
+    put:
+      tags:
+        - AcademicDepartment
+        - AcademicDepartmentBulk
+      summary: Update one or more AcademicDepartments
+      description: Bulk operation to update all available AcademicDepartments, within the scope of the given Provider.  Each AcademicDepartment groups <a href="#tagProviderCourse">ProviderCourses</a> and  <a href="#tagTeachingGroup">TeachingGroups</a> according to SubjectArea.</p>
+      operationId: updateAcademicDepartments
+      parameters:
+        - $ref: "#/paths/~1staffpersonal/post/parameters/2"
+        - $ref: "#/paths/~1search/get/parameters/6"
+      requestBody:
+        description: CRUD operation on AcademicDepartment
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                AcademicDepartments:
+                  $ref: jsonSchema.NZ.create.yaml#/properties/AcademicDepartments
+            example:
+              $ref: "#/paths/~1academicdepartment/post/requestBody/content/application~1json/example"
+          application/xml:
+            schema:
+              type: object
+              properties:
+                AcademicDepartments:
+                  $ref: jsonSchema.NZ.create.yaml#/properties/AcademicDepartments
+            example:
+              $ref: "#/paths/~1academicdepartment/post/requestBody/content/application~1xml/example"
+      responses:
+        "200":
+          description: Update successful; returns updated objects
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  AcademicDepartments:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/AcademicDepartments
+              example:
+                $ref: "#/paths/~1academicdepartment/post/requestBody/content/application~1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  AcademicDepartments:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/AcademicDepartments
+              example:
+                $ref: "#/paths/~1academicdepartment/post/requestBody/content/application~1xml/example"
+        "401":
+          $ref: "#/paths/~1search/get/responses/401"
+        "422":
+          $ref: "#/paths/~1search/get/responses/422"
+        default:
+          description: Some objects updated, some updates failed
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  anyOf:
+                    - type: object
+                      title: Error
+                      properties:
+                        Error:
+                          $ref: "#/paths/~1organisation/post/responses/default/content/application~1json/schema/items/anyOf/0/properties/Error"
+                    - type: object
+                      title: AcademicDepartment
+                      properties:
+                        AcademicDepartment:
+                          $ref: jsonSchema.NZ.create.yaml#/properties/AcademicDepartment
+              example:
+                $ref: "#/paths/~1academicdepartment/post/responses/default/content/application~1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  Response:
+                    type: array
+                    items:
+                      anyOf:
+                        - type: object
+                          title: Error
+                          properties:
+                            Error:
+                              $ref: "#/paths/~1organisation/post/responses/default/content/application~1xml/schema/properties/Response/items/anyOf/0/properties/Error"
+                        - type: object
+                          title: AcademicDepartment
+                          properties:
+                            AcademicDepartment:
+                              $ref: jsonSchema.NZ.create.yaml#/properties/AcademicDepartment
+              example:
+                $ref: "#/paths/~1academicdepartment/post/responses/default/content/application~1xml/example"
+    patch:
+      tags:
+        - AcademicDepartment
+        - AcademicDepartmentBulk
+      summary: Patch one or more AcademicDepartments
+      description: Bulk operation to update one or more fields of one or more AcademicDepartments, within the scope of the given Provider.  Each AcademicDepartment groups <a href="#tagProviderCourse">ProviderCourses</a> and  <a href="#tagTeachingGroup">TeachingGroups</a> according to SubjectArea.</p>
+      operationId: patchAcademicDepartments
+      parameters:
+        - $ref: "#/paths/~1staffpersonal/post/parameters/2"
+        - $ref: "#/paths/~1search/get/parameters/6"
+      requestBody:
+        description: CRUD operation on AcademicDepartment
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                AcademicDepartments:
+                  $ref: jsonSchema.NZ.update.yaml#/properties/AcademicDepartments
+            example:
+              $ref: "#/paths/~1academicdepartment/post/requestBody/content/application~1json/example"
+          application/xml:
+            schema:
+              type: object
+              properties:
+                AcademicDepartments:
+                  $ref: jsonSchema.NZ.update.yaml#/properties/AcademicDepartments
+            example:
+              $ref: "#/paths/~1academicdepartment/post/requestBody/content/application~1xml/example"
+      responses:
+        "200":
+          description: Patch successful; returns patched objects
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  AcademicDepartments:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/AcademicDepartments
+              example:
+                $ref: "#/paths/~1academicdepartment/post/requestBody/content/application~1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  AcademicDepartments:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/AcademicDepartments
+              example:
+                $ref: "#/paths/~1academicdepartment/post/requestBody/content/application~1xml/example"
+        "401":
+          $ref: "#/paths/~1search/get/responses/401"
+        "422":
+          $ref: "#/paths/~1search/get/responses/422"
+        default:
+          description: Some objects patched, some patches failed
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  anyOf:
+                    - type: object
+                      title: Error
+                      properties:
+                        Error:
+                          $ref: "#/paths/~1organisation/post/responses/default/content/application~1json/schema/items/anyOf/0/properties/Error"
+                    - type: object
+                      title: AcademicDepartment
+                      properties:
+                        AcademicDepartment:
+                          $ref: jsonSchema.NZ.create.yaml#/properties/AcademicDepartment
+              example:
+                $ref: "#/paths/~1academicdepartment/post/responses/default/content/application~1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  Response:
+                    type: array
+                    items:
+                      anyOf:
+                        - type: object
+                          title: Error
+                          properties:
+                            Error:
+                              $ref: "#/paths/~1organisation/post/responses/default/content/application~1xml/schema/properties/Response/items/anyOf/0/properties/Error"
+                        - type: object
+                          title: AcademicDepartment
+                          properties:
+                            AcademicDepartment:
+                              $ref: jsonSchema.NZ.create.yaml#/properties/AcademicDepartment
+              example:
+                $ref: "#/paths/~1academicdepartment/post/responses/default/content/application~1xml/example"
+  "/academicdepartment/{AcademicDepartmentRefId}":
+    get:
+      tags:
+        - AcademicDepartment
+        - AcademicDepartmentSingle
+      summary: Retrieve a single AcademicDepartment
+      description: Retrieve a particular AcademicDepartment which groups <a href="#tagProviderCourse">ProviderCourses</a> and  <a href="#tagTeachingGroup">TeachingGroups</a> according to SubjectArea.</p>
+      operationId: getAcademicDepartment
+      parameters:
+        - $ref: "#/paths/~1organisation/get/parameters/0"
+        - $ref: "#/paths/~1search/get/parameters/4"
+        - $ref: "#/paths/~1search/get/parameters/3"
+        - $ref: "#/paths/~1organisation/get/parameters/3"
+        - $ref: "#/paths/~1search/get/parameters/5"
+        - $ref: "#/paths/~1organisation/get/parameters/5"
+        - $ref: "#/paths/~1organisation/get/parameters/6"
+        - $ref: "#/paths/~1organisation/get/parameters/7"
+        - $ref: "#/paths/~1staffpersonal/post/parameters/2"
+        - $ref: "#/paths/~1search/get/parameters/6"
+        - name: AcademicDepartmentRefId
+          in: path
+          description: <p>The ID (GUID) assigned to uniquely identify this AcademicDepartment.</p>
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  AcademicDepartment:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/AcademicDepartment
+              example:
+                AcademicDepartment:
+                  AcademicDepartmentRefId: 2ffb63b4-cfef-4820-8501-e7d1e54555cb
+                  Name: Science Department
+                  Provider:
+                    RefId: "9651"
+                  StaffList:
+                    StaffMember:
+                      - RefId: 44fb63b4-cfef-4820-8501-e7d1e54555cb
+                        Name: Bobby Test
+                        Role: "1205"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  AcademicDepartment:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/AcademicDepartment
+              example: >-
+                <AcademicDepartment>
+                  </AcademicDepartmentRefId>2ffb63b4-cfef-4820-8501-e7d1e54555cb</AcademicDepartmentRefId>
+                  </Name>Science Department</Name>
+                  <Provider>
+                    </RefId>9651</RefId>
+                  </Provider>
+                  <StaffList>
+                    <StaffMember>
+                      </RefId>44fb63b4-cfef-4820-8501-e7d1e54555cb</RefId>
+                      </Name>Bobby Test</Name>
+                      <Role>1205</Role>
+                    </StaffMember>
+                  </StaffList>
+                </AcademicDepartment>
+        "401":
+          $ref: "#/paths/~1search/get/responses/401"
+        "422":
+          $ref: "#/paths/~1search/get/responses/422"
+        default:
+          $ref: "#/paths/~1organisation/get/responses/default"
+    put:
+      tags:
+        - AcademicDepartment
+        - AcademicDepartmentSingle
+      summary: Update a single AcademicDepartment
+      description: Update a particular AcademicDepartment which groups <a href="#tagProviderCourse">ProviderCourses</a> and  <a href="#tagTeachingGroup">TeachingGroups</a> according to SubjectArea.</p>
+      operationId: updateAcademicDepartment
+      parameters:
+        - $ref: "#/paths/~1staffpersonal/post/parameters/2"
+        - $ref: "#/paths/~1search/get/parameters/6"
+        - name: AcademicDepartmentRefId
+          in: path
+          description: <p>The ID (GUID) assigned to uniquely identify this AcademicDepartment.</p>
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: CRUD operation on AcademicDepartment
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                AcademicDepartment:
+                  $ref: jsonSchema.NZ.create.yaml#/properties/AcademicDepartment
+            example:
+              $ref: "#/paths/~1academicdepartment~1%7BAcademicDepartmentRefId%7D/get/responses/200/content/application~1json/example"
+          application/xml:
+            schema:
+              type: object
+              properties:
+                AcademicDepartment:
+                  $ref: jsonSchema.NZ.create.yaml#/properties/AcademicDepartment
+            example:
+              $ref: "#/paths/~1academicdepartment~1%7BAcademicDepartmentRefId%7D/get/responses/200/content/application~1xml/example"
+      responses:
+        "200":
+          description: Update successful; returns updated object
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  AcademicDepartment:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/AcademicDepartment
+              example:
+                $ref: "#/paths/~1academicdepartment~1%7BAcademicDepartmentRefId%7D/get/responses/200/content/application~1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  AcademicDepartment:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/AcademicDepartment
+              example:
+                $ref: "#/paths/~1academicdepartment~1%7BAcademicDepartmentRefId%7D/get/responses/200/content/application~1xml/example"
+        "401":
+          $ref: "#/paths/~1search/get/responses/401"
+        "422":
+          $ref: "#/paths/~1search/get/responses/422"
+        default:
+          $ref: "#/paths/~1organisation~1%7BOrganisationRefId%7D/put/responses/default"
+    patch:
+      tags:
+        - AcademicDepartment
+        - AcademicDepartmentSingle
+      summary: Patch a single AcademicDepartment
+      description: Update one or more fields of a particular AcademicDepartment which groups <a href="#tagProviderCourse">ProviderCourses</a> and  <a href="#tagTeachingGroup">TeachingGroups</a> according to SubjectArea.</p>
+      operationId: patchAcademicDepartment
+      parameters:
+        - $ref: "#/paths/~1staffpersonal/post/parameters/2"
+        - $ref: "#/paths/~1search/get/parameters/6"
+        - name: AcademicDepartmentRefId
+          in: path
+          description: <p>The ID (GUID) assigned to uniquely identify this AcademicDepartment.</p>
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: CRUD operation on AcademicDepartment
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                AcademicDepartment:
+                  $ref: jsonSchema.NZ.update.yaml#/properties/AcademicDepartment
+            example:
+              $ref: "#/paths/~1academicdepartment~1%7BAcademicDepartmentRefId%7D/get/responses/200/content/application~1json/example"
+          application/xml:
+            schema:
+              type: object
+              properties:
+                AcademicDepartment:
+                  $ref: jsonSchema.NZ.update.yaml#/properties/AcademicDepartment
+            example:
+              $ref: "#/paths/~1academicdepartment~1%7BAcademicDepartmentRefId%7D/get/responses/200/content/application~1xml/example"
+      responses:
+        "200":
+          description: Patch successful; returns patched object
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  AcademicDepartment:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/AcademicDepartment
+              example:
+                $ref: "#/paths/~1academicdepartment~1%7BAcademicDepartmentRefId%7D/get/responses/200/content/application~1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  AcademicDepartment:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/AcademicDepartment
+              example:
+                $ref: "#/paths/~1academicdepartment~1%7BAcademicDepartmentRefId%7D/get/responses/200/content/application~1xml/example"
+        "401":
+          $ref: "#/paths/~1search/get/responses/401"
+        "422":
+          $ref: "#/paths/~1search/get/responses/422"
+        default:
+          $ref: "#/paths/~1organisation~1%7BOrganisationRefId%7D/patch/responses/default"
+  /providercourse:
+    post:
+      tags:
+        - ProviderCourse
+        - ProviderCourseBulk
+      summary: Create one or more ProviderCourses
+      description: <p>Bulk operation to create one or more provider defined Courses that Students enrol in,  may be assessed for, and achieve passes in.</p>
+      operationId: createProviderCourses
+      parameters:
+        - $ref: "#/paths/~1organisation/post/parameters/0"
+        - $ref: "#/paths/~1search/get/parameters/6"
+        - $ref: "#/paths/~1staffpersonal/post/parameters/2"
+      requestBody:
+        description: CRUD operation on ProviderCourse
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                ProviderCourses:
+                  $ref: jsonSchema.NZ.create.yaml#/properties/ProviderCourses
+            example:
+              ProviderCourses:
+                ProviderCourse:
+                  - ProviderCourseRefId: 9d75101a-8c3d-00aa-001a-0000a2e35b35
+                    ProviderCourseLocalId: 12CHEM
+                    Provider:
+                      RefId: "9651"
+                    Curriculum: NZC
+                    SubjectAreaList:
+                      SubjectArea:
+                        - CHEM
+                    YearLevelList:
+                      YearLevel:
+                        - 12
+                    Title: Year 12 Chemistry
+                    Description: Organic & Inorganic Chemistry for NCEA Level 2
+                    Duration: 35
+                    Credits: 11
+                    LearningStandardList:
+                      LearningStandardRefId:
+                        - NC-91165-2
+                        - NC-91166-2
+                        - NC-91167-2
+          application/xml:
+            schema:
+              type: object
+              properties:
+                ProviderCourses:
+                  $ref: jsonSchema.NZ.create.yaml#/properties/ProviderCourses
+            example: >-
+              <ProviderCourses>
+                <ProviderCourse>
+                  </ProviderCourseRefId>9d75101a-8c3d-00aa-001a-0000a2e35b35</ProviderCourseRefId>
+                  </ProviderCourseLocalId>12CHEM</ProviderCourseLocalId>
+                  <Provider>
+                    </RefId>101a8c3d-00aa-001a-0000-a2e35b359d75</RefId>
+                    </LocalId>208</LocalId>
+                  </Provider>
+                  </Curriculum>NZC</Curriculum>
+                  <SubjectAreaList>
+                    </SubjectArea>CHEM</SubjectArea>
+                  </SubjectAreaList>
+                  <YearLevelList>
+                    </YearLevel>12</YearLevel>
+                  </YearLevelList>
+                  </Title>Year 12 Chemistry</Title>
+                  </Description>Organic & Inorganic Chemistry for NCEA Level 2</Description>
+                  </Duration>35</Duration>
+                  </Credits>11</Credits>
+                  <LanguageOfInstructionList>
+                    <Language>
+                      </Code>NZS01112</Code>
+                      </Level>1</Level>
+                    </Language>
+                  </LanguageOfInstructionList>
+                  <LearningStandardList>
+                    <LearningStandardList>
+                      <LearningStandardRefId>NC-91165-2</LocalId>
+                      <LearningStandardRefId>NC-91166-2</LocalId>
+                      <LearningStandardRefId>MC-91167-2</LocalId>
+                    </LearningStandardList>
+                  </LearningStandardList>
+                </ProviderCourse>
+              </ProviderCourses>
+      responses:
+        "200":
+          description: All objects created; returns created objects
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ProviderCourses:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/ProviderCourses
+              example:
+                $ref: "#/paths/~1providercourse/post/requestBody/content/application~1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  ProviderCourses:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/ProviderCourses
+              example:
+                $ref: "#/paths/~1providercourse/post/requestBody/content/application~1xml/example"
+        "401":
+          $ref: "#/paths/~1search/get/responses/401"
+        "422":
+          $ref: "#/paths/~1search/get/responses/422"
+        default:
+          description: Some objects created, some creates failed
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  anyOf:
+                    - type: object
+                      title: Error
+                      properties:
+                        Error:
+                          $ref: "#/paths/~1organisation/post/responses/default/content/application~1json/schema/items/anyOf/0/properties/Error"
+                    - type: object
+                      title: ProviderCourse
+                      properties:
+                        ProviderCourse:
+                          $ref: jsonSchema.NZ.create.yaml#/properties/ProviderCourse
+              example:
+                - ProviderCourse:
+                    ProviderCourseRefId: 9d75101a-8c3d-00aa-001a-0000a2e35b35
+                    ProviderCourseLocalId: 12CHEM
+                    Provider:
+                      RefId: "9651"
+                    Curriculum: NZC
+                    SubjectAreaList:
+                      SubjectArea:
+                        - CHEM
+                    YearLevelList:
+                      YearLevel:
+                        - 12
+                    Title: Year 12 Chemistry
+                    Description: Organic & Inorganic Chemistry for NCEA Level 2
+                    Duration: 35
+                    Credits: 11
+                    LearningStandardList:
+                      LearningStandardRefId:
+                        - NC-91165-2
+                        - NC-91166-2
+                        - NC-91167-2
+                - Error:
+                    error: 1009
+                    when: 2020-07-16T20:00:46.000Z
+                    errorstr: "Bad field: PersonInfo-Name-FamilyName: missing required field PersonInfo-Name-FamilyName (LastName) 'None'"
+                    localId: ST-002
+                    refId: null
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  Response:
+                    type: array
+                    items:
+                      anyOf:
+                        - type: object
+                          title: Error
+                          properties:
+                            Error:
+                              $ref: "#/paths/~1organisation/post/responses/default/content/application~1xml/schema/properties/Response/items/anyOf/0/properties/Error"
+                        - type: object
+                          title: ProviderCourse
+                          properties:
+                            ProviderCourse:
+                              $ref: jsonSchema.NZ.create.yaml#/properties/ProviderCourse
+              example: >-
+                <Response>
+                  <ProviderCourse>
+                    </ProviderCourseRefId>9d75101a-8c3d-00aa-001a-0000a2e35b35</ProviderCourseRefId>
+                    </ProviderCourseLocalId>12CHEM</ProviderCourseLocalId>
+                    <Provider>
+                      </RefId>101a8c3d-00aa-001a-0000-a2e35b359d75</RefId>
+                      </LocalId>208</LocalId>
+                    </Provider>
+                    </Curriculum>NZC</Curriculum>
+                    <SubjectAreaList>
+                      </SubjectArea>CHEM</SubjectArea>
+                    </SubjectAreaList>
+                    <YearLevelList>
+                      </YearLevel>12</YearLevel>
+                    </YearLevelList>
+                    </Title>Year 12 Chemistry</Title>
+                    </Description>Organic & Inorganic Chemistry for NCEA Level 2</Description>
+                    </Duration>35</Duration>
+                    </Credits>11</Credits>
+                    <LanguageOfInstructionList>
+                      <Language>
+                        </Code>NZS01112</Code>
+                        </Level>1</Level>
+                      </Language>
+                    </LanguageOfInstructionList>
+                    <LearningStandardList>
+                      <LearningStandardList>
+                        <LearningStandardRefId>NC-91165-2</LocalId>
+                        <LearningStandardRefId>NC-91166-2</LocalId>
+                        <LearningStandardRefId>MC-91167-2</LocalId>
+                      </LearningStandardList>
+                    </LearningStandardList>
+                  </ProviderCourse>  
+                  <Error>
+                    <error>1009</error>
+                    <when>2020-07-16T20:00:46.000Z</when>
+                    <errorstr>Bad field: PersonInfo-Name-FamilyName: missing required field PersonInfo-Name-FamilyName (LastName) 'None'</errorstr>
+                    <localId>ST-002</localId>
+                    <refId/>
+                  </Error>      
+                </Response>
+    get:
+      tags:
+        - ProviderCourse
+        - ProviderCourseBulk
+      summary: Retrieve one or more ProviderCourses
+      description: "<p>Bulk operation to retrieve one or more provider defined Courses that Students enrol in,  may be assessed for, and achieve passes in.</p>    "
+      operationId: getProviderCourses
+      parameters:
+        - $ref: "#/paths/~1organisation/get/parameters/0"
+        - $ref: "#/paths/~1search/get/parameters/4"
+        - $ref: "#/paths/~1search/get/parameters/3"
+        - $ref: "#/paths/~1organisation/get/parameters/3"
+        - $ref: "#/paths/~1search/get/parameters/5"
+        - $ref: "#/paths/~1organisation/get/parameters/5"
+        - $ref: "#/paths/~1organisation/get/parameters/6"
+        - $ref: "#/paths/~1organisation/get/parameters/7"
+        - $ref: "#/paths/~1search/get/parameters/6"
+        - $ref: "#/paths/~1staffpersonal/post/parameters/2"
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ProviderCourses:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/ProviderCourses
+              example:
+                $ref: "#/paths/~1providercourse/post/requestBody/content/application~1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  ProviderCourses:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/ProviderCourses
+              example:
+                $ref: "#/paths/~1providercourse/post/requestBody/content/application~1xml/example"
+        "401":
+          $ref: "#/paths/~1search/get/responses/401"
+        "422":
+          $ref: "#/paths/~1search/get/responses/422"
+        default:
+          $ref: "#/paths/~1organisation/get/responses/default"
+    put:
+      tags:
+        - ProviderCourse
+        - ProviderCourseBulk
+      summary: Update one or more ProviderCourses
+      description: "<p>Bulk operation to update one or more provider defined Courses that Students enrol in,  may be assessed for, and achieve passes in.</p>    "
+      operationId: updateProviderCourses
+      parameters:
+        - $ref: "#/paths/~1search/get/parameters/6"
+        - $ref: "#/paths/~1staffpersonal/post/parameters/2"
+      requestBody:
+        description: CRUD operation on ProviderCourse
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                ProviderCourses:
+                  $ref: jsonSchema.NZ.create.yaml#/properties/ProviderCourses
+            example:
+              $ref: "#/paths/~1providercourse/post/requestBody/content/application~1json/example"
+          application/xml:
+            schema:
+              type: object
+              properties:
+                ProviderCourses:
+                  $ref: jsonSchema.NZ.create.yaml#/properties/ProviderCourses
+            example:
+              $ref: "#/paths/~1providercourse/post/requestBody/content/application~1xml/example"
+      responses:
+        "200":
+          description: All objects updated; returns updated objects
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ProviderCourses:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/ProviderCourses
+              example:
+                $ref: "#/paths/~1providercourse/post/requestBody/content/application~1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  ProviderCourses:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/ProviderCourses
+              example:
+                $ref: "#/paths/~1providercourse/post/requestBody/content/application~1xml/example"
+        "401":
+          $ref: "#/paths/~1search/get/responses/401"
+        "422":
+          $ref: "#/paths/~1search/get/responses/422"
+        default:
+          description: Some objects updated, some updates failed
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  anyOf:
+                    - type: object
+                      title: Error
+                      properties:
+                        Error:
+                          $ref: "#/paths/~1organisation/post/responses/default/content/application~1json/schema/items/anyOf/0/properties/Error"
+                    - type: object
+                      title: ProviderCourse
+                      properties:
+                        ProviderCourse:
+                          $ref: jsonSchema.NZ.create.yaml#/properties/ProviderCourse
+              example:
+                $ref: "#/paths/~1providercourse/post/responses/default/content/application~1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  Response:
+                    type: array
+                    items:
+                      anyOf:
+                        - type: object
+                          title: Error
+                          properties:
+                            Error:
+                              $ref: "#/paths/~1organisation/post/responses/default/content/application~1xml/schema/properties/Response/items/anyOf/0/properties/Error"
+                        - type: object
+                          title: ProviderCourse
+                          properties:
+                            ProviderCourse:
+                              $ref: jsonSchema.NZ.create.yaml#/properties/ProviderCourse
+              example:
+                $ref: "#/paths/~1providercourse/post/responses/default/content/application~1xml/example"
+    patch:
+      tags:
+        - ProviderCourse
+        - ProviderCourseBulk
+      summary: Patch one or more ProviderCourses
+      description: <p>Bulk operation to update one or more fields of one or more provider defined Courses that Students enrol in, may be assessed for, and achieve passes in.</p>
+      operationId: patchProviderCourses
+      parameters:
+        - $ref: "#/paths/~1search/get/parameters/6"
+        - $ref: "#/paths/~1staffpersonal/post/parameters/2"
+      requestBody:
+        description: CRUD operation on ProviderCourse
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                ProviderCourses:
+                  $ref: jsonSchema.NZ.update.yaml#/properties/ProviderCourses
+            example:
+              $ref: "#/paths/~1providercourse/post/requestBody/content/application~1json/example"
+          application/xml:
+            schema:
+              type: object
+              properties:
+                ProviderCourses:
+                  $ref: jsonSchema.NZ.update.yaml#/properties/ProviderCourses
+            example:
+              $ref: "#/paths/~1providercourse/post/requestBody/content/application~1xml/example"
+      responses:
+        "200":
+          description: All objects patched; returns patched objects
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ProviderCourses:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/ProviderCourses
+              example:
+                $ref: "#/paths/~1providercourse/post/requestBody/content/application~1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  ProviderCourses:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/ProviderCourses
+              example:
+                $ref: "#/paths/~1providercourse/post/requestBody/content/application~1xml/example"
+        "401":
+          $ref: "#/paths/~1search/get/responses/401"
+        "422":
+          $ref: "#/paths/~1search/get/responses/422"
+        default:
+          description: Some objects patched, some patches failed
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  anyOf:
+                    - type: object
+                      title: Error
+                      properties:
+                        Error:
+                          $ref: "#/paths/~1organisation/post/responses/default/content/application~1json/schema/items/anyOf/0/properties/Error"
+                    - type: object
+                      title: ProviderCourse
+                      properties:
+                        ProviderCourse:
+                          $ref: jsonSchema.NZ.create.yaml#/properties/ProviderCourse
+              example:
+                $ref: "#/paths/~1providercourse/post/responses/default/content/application~1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  Response:
+                    type: array
+                    items:
+                      anyOf:
+                        - type: object
+                          title: Error
+                          properties:
+                            Error:
+                              $ref: "#/paths/~1organisation/post/responses/default/content/application~1xml/schema/properties/Response/items/anyOf/0/properties/Error"
+                        - type: object
+                          title: ProviderCourse
+                          properties:
+                            ProviderCourse:
+                              $ref: jsonSchema.NZ.create.yaml#/properties/ProviderCourse
+              example:
+                $ref: "#/paths/~1providercourse/post/responses/default/content/application~1xml/example"
+  "/providercourse/{ProviderCourseRefId}":
+    get:
+      tags:
+        - ProviderCourse
+        - ProviderCourseSingle
+      summary: Retrieve a single ProviderCourse
+      description: "<p>Retrieve a particular provider defined Course that Students enrol in,  may be assessed for, and achieve passes in.</p>    "
+      operationId: getProviderCourse
+      parameters:
+        - $ref: "#/paths/~1organisation/get/parameters/0"
+        - $ref: "#/paths/~1search/get/parameters/4"
+        - $ref: "#/paths/~1search/get/parameters/3"
+        - $ref: "#/paths/~1organisation/get/parameters/3"
+        - $ref: "#/paths/~1search/get/parameters/5"
+        - $ref: "#/paths/~1organisation/get/parameters/5"
+        - $ref: "#/paths/~1organisation/get/parameters/6"
+        - $ref: "#/paths/~1organisation/get/parameters/7"
+        - $ref: "#/paths/~1staffpersonal/post/parameters/2"
+        - $ref: "#/paths/~1search/get/parameters/6"
+        - name: ProviderCourseRefId
+          in: path
+          description: <p>The ID (GUID) that uniquely identifies the Provider defined Course.</p>
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ProviderCourse:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/ProviderCourse
+              example:
+                ProviderCourse:
+                  ProviderCourseRefId: 9d75101a-8c3d-00aa-001a-0000a2e35b35
+                  ProviderCourseLocalId: 12CHEM
+                  Provider:
+                    RefId: "9651"
+                  Curriculum: NZC
+                  SubjectAreaList:
+                    SubjectArea:
+                      - CHEM
+                  YearLevelList:
+                    YearLevel:
+                      - 12
+                  Title: Year 12 Chemistry
+                  Description: Organic & Inorganic Chemistry for NCEA Level 2
+                  Duration: 35
+                  Credits: 11
+                  LearningStandardList:
+                    LearningStandardRefId:
+                      - NC-91165-2
+                      - NC-91166-2
+                      - NC-91167-2
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  ProviderCourse:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/ProviderCourse
+              example: >-
+                <ProviderCourse>
+                  </ProviderCourseRefId>9d75101a-8c3d-00aa-001a-0000a2e35b35</ProviderCourseRefId>
+                  </ProviderCourseLocalId>12CHEM</ProviderCourseLocalId>
+                  <Provider>
+                    </RefId>101a8c3d-00aa-001a-0000-a2e35b359d75</RefId>
+                    </LocalId>208</LocalId>
+                  </Provider>
+                  </Curriculum>NZC</Curriculum>
+                  <SubjectAreaList>
+                    </SubjectArea>CHEM</SubjectArea>
+                  </SubjectAreaList>
+                  <YearLevelList>
+                    </YearLevel>12</YearLevel>
+                  </YearLevelList>
+                  </Title>Year 12 Chemistry</Title>
+                  </Description>Organic & Inorganic Chemistry for NCEA Level 2</Description>
+                  </Duration>35</Duration>
+                  </Credits>11</Credits>
+                  <LanguageOfInstructionList>
+                    <Language>
+                      </Code>NZS01112</Code>
+                      </Level>1</Level>
+                    </Language>
+                  </LanguageOfInstructionList>
+                  <LearningStandardList>
+                    <LearningStandardRefId>NC-91165-2</LocalId>
+                    <LearningStandardRefId>NC-91166-2</LocalId>
+                    <LearningStandardRefId>MC-91167-2</LocalId>
+                  </LearningStandardList>
+                </ProviderCourse>  
+        "401":
+          $ref: "#/paths/~1search/get/responses/401"
+        "422":
+          $ref: "#/paths/~1search/get/responses/422"
+        default:
+          $ref: "#/paths/~1organisation/get/responses/default"
+    put:
+      tags:
+        - ProviderCourse
+        - ProviderCourseSingle
+      summary: Update a single ProviderCourse
+      description: <p>Update one or more fields of a particular provider defined Course that Students enrol in,  may be assessed for, and achieve passes in.</p>
+      operationId: updateProviderCourse
+      parameters:
+        - $ref: "#/paths/~1search/get/parameters/6"
+        - $ref: "#/paths/~1staffpersonal/post/parameters/2"
+        - name: ProviderCourseRefId
+          in: path
+          description: <p>The ID (GUID) that uniquely identifies the Provider defined Course.</p>
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: CRUD operation on ProviderCourse
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                ProviderCourse:
+                  $ref: jsonSchema.NZ.create.yaml#/properties/ProviderCourse
+            example:
+              $ref: "#/paths/~1providercourse~1%7BProviderCourseRefId%7D/get/responses/200/content/application~1json/example"
+          application/xml:
+            schema:
+              type: object
+              properties:
+                ProviderCourse:
+                  $ref: jsonSchema.NZ.create.yaml#/properties/ProviderCourse
+            example:
+              $ref: "#/paths/~1providercourse~1%7BProviderCourseRefId%7D/get/responses/200/content/application~1xml/example"
+      responses:
+        "200":
+          description: Update successful; returns updated object
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ProviderCourse:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/ProviderCourse
+              example:
+                $ref: "#/paths/~1providercourse~1%7BProviderCourseRefId%7D/get/responses/200/content/application~1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  ProviderCourse:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/ProviderCourse
+              example:
+                $ref: "#/paths/~1providercourse~1%7BProviderCourseRefId%7D/get/responses/200/content/application~1xml/example"
+        "401":
+          $ref: "#/paths/~1search/get/responses/401"
+        "422":
+          $ref: "#/paths/~1search/get/responses/422"
+        default:
+          $ref: "#/paths/~1organisation~1%7BOrganisationRefId%7D/put/responses/default"
+    patch:
+      tags:
+        - ProviderCourse
+        - ProviderCourseSingle
+      summary: Patch a single ProviderCourse
+      description: <p>Update one or more fields of a particular provider defined Course that Students enrol in,  may be assessed for, and achieve passes in.</p>
+      operationId: patchProviderCourse
+      parameters:
+        - $ref: "#/paths/~1search/get/parameters/6"
+        - $ref: "#/paths/~1staffpersonal/post/parameters/2"
+        - name: ProviderCourseRefId
+          in: path
+          description: <p>The ID (GUID) that uniquely identifies the Provider defined Course.</p>
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: CRUD operation on ProviderCourse
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                ProviderCourse:
+                  $ref: jsonSchema.NZ.update.yaml#/properties/ProviderCourse
+            example:
+              $ref: "#/paths/~1providercourse~1%7BProviderCourseRefId%7D/get/responses/200/content/application~1json/example"
+          application/xml:
+            schema:
+              type: object
+              properties:
+                ProviderCourse:
+                  $ref: jsonSchema.NZ.update.yaml#/properties/ProviderCourse
+            example:
+              $ref: "#/paths/~1providercourse~1%7BProviderCourseRefId%7D/get/responses/200/content/application~1xml/example"
+      responses:
+        "200":
+          description: Patch successful; returns patched object
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ProviderCourse:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/ProviderCourse
+              example:
+                $ref: "#/paths/~1providercourse~1%7BProviderCourseRefId%7D/get/responses/200/content/application~1json/example"
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  ProviderCourse:
+                    $ref: jsonSchema.NZ.create.yaml#/properties/ProviderCourse
+              example:
+                $ref: "#/paths/~1providercourse~1%7BProviderCourseRefId%7D/get/responses/200/content/application~1xml/example"
+        "401":
+          $ref: "#/paths/~1search/get/responses/401"
+        "422":
+          $ref: "#/paths/~1search/get/responses/422"
+        default:
+          $ref: "#/paths/~1organisation~1%7BOrganisationRefId%7D/patch/responses/default"

--- a/openapi-filter.js
+++ b/openapi-filter.js
@@ -28,6 +28,8 @@ let argv = require('yargs')
     .array('flagValues')
     .alias('flagValues', 'v')
     .describe('flagValues', 'flag string values to consider as a filter match (in addition to matching on boolean types)')
+    .array('scopes')
+    .describe('scopes', 'filter based upon oauth security scheme scopes, instead of \'x-internal\' flags')
     .default('flagValues', [])
     .boolean('checkTags')
     .describe('checkTags', 'filter if flags given in --flags are in the tags array')
@@ -50,6 +52,12 @@ let argv = require('yargs')
     .help()
     .version()
     .argv;
+
+//  --scopes on the cmdline  turns on checkScopes options, and the listed scopes move to flags; to make the code simpler...
+if(argv.scopes) {
+    argv.flags = argv.scopes;
+    argv.checkScopes = true;
+}
 
 let s = fs.readFileSync(argv.infile,'utf8');
 let obj = yaml.parse(s, {maxAliasCount: argv.maxAliasCount});

--- a/test/scopes1/input.yaml
+++ b/test/scopes1/input.yaml
@@ -1,0 +1,686 @@
+openapi: 3.0.0
+servers:
+  - url: http://petstore.swagger.io/v2
+x-origin:
+  - url: http://petstore.swagger.io/v2/swagger.json
+    format: swagger
+    version: "2.0"
+    converter:
+      url: https://github.com/mermade/swagger2openapi
+      version: 2.6.3
+info:
+  description: "This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key `special-key` to test the authorization filters."
+  version: 1.0.0
+  title: Swagger Petstore
+  termsOfService: http://swagger.io/terms/
+  contact:
+    email: apiteam@swagger.io
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+security:
+  - api_key: []
+tags:
+  - name: pet
+    description: Everything about your Pets
+    externalDocs:
+      description: Find out more
+      url: http://swagger.io
+  - name: store
+    description: Access to Petstore orders
+  - name: user
+    description: Operations about user
+    externalDocs:
+      description: Find out more about our store
+      url: http://swagger.io
+paths:
+  /pet:
+    post:
+      tags:
+        - pet
+      summary: Add a new pet to the store
+      description: ""
+      operationId: addPet
+      responses:
+        "405":
+          description: Invalid input
+      security:
+        - petstore_auth:
+            - write:pets
+      requestBody:
+        $ref: "#/components/requestBodies/Pet"
+    put:
+      tags:
+        - pet
+      summary: Update an existing pet
+      description: ""
+      operationId: updatePet
+      responses:
+        "400":
+          description: Invalid ID supplied
+        "404":
+          description: Pet not found
+        "405":
+          description: Validation exception
+      security:
+        - petstore_auth:
+            - write:pets
+      requestBody:
+        $ref: "#/components/requestBodies/Pet"
+  /pet/findByStatus:
+    get:
+      tags:
+        - pet
+      summary: Finds Pets by status
+      description: Multiple status values can be provided with comma separated strings
+      operationId: findPetsByStatus
+      parameters:
+        - name: status
+          in: query
+          description: Status values that need to be considered for filter
+          required: true
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - available
+                - pending
+                - sold
+              default: available
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Pet"
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Pet"
+        "400":
+          description: Invalid status value
+      security:
+        - petstore_auth:
+            - read:pets
+  /pet/findByTags:
+    get:
+      tags:
+        - pet
+      summary: Finds Pets by tags
+      description: Muliple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
+      operationId: findPetsByTags
+      parameters:
+        - name: tags
+          in: query
+          description: Tags to filter by
+          required: true
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Pet"
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Pet"
+        "400":
+          description: Invalid tag value
+      security:
+        - petstore_auth:
+            - read:pets
+      deprecated: true
+  "/pet/{petId}":
+    get:
+      tags:
+        - pet
+      summary: Find pet by ID
+      description: Returns a single pet
+      operationId: getPetById
+      parameters:
+        - name: petId
+          in: path
+          description: ID of pet to return
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                $ref: "#/components/schemas/Pet"
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+        "400":
+          description: Invalid ID supplied
+        "404":
+          description: Pet not found
+      security:
+        - api_key: []
+    post:
+      tags:
+        - pet
+      summary: Updates a pet in the store with form data
+      description: ""
+      operationId: updatePetWithForm
+      parameters:
+        - name: petId
+          in: path
+          description: ID of pet that needs to be updated
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        "405":
+          description: Invalid input
+      security:
+        - petstore_auth:
+            - write:pets
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                name:
+                  description: Updated name of the pet
+                  type: string
+                status:
+                  description: Updated status of the pet
+                  type: string
+    delete:
+      tags:
+        - pet
+      summary: Deletes a pet
+      description: ""
+      operationId: deletePet
+      parameters:
+        - name: api_key
+          in: header
+          required: false
+          schema:
+            type: string
+        - name: petId
+          in: path
+          description: Pet id to delete
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        "400":
+          description: Invalid ID supplied
+        "404":
+          description: Pet not found
+      security:
+        - petstore_auth:
+            - write:pets
+  "/pet/{petId}/uploadImage":
+    post:
+      tags:
+        - pet
+      summary: uploads an image
+      description: ""
+      operationId: uploadFile
+      parameters:
+        - name: petId
+          in: path
+          description: ID of pet to update
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiResponse"
+      security:
+        - petstore_auth:
+            - write:pets
+      requestBody:
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+  /store/inventory:
+    get:
+      tags:
+        - store
+      summary: Returns pet inventories by status
+      description: Returns a map of status codes to quantities
+      operationId: getInventory
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: integer
+                  format: int32
+      security:
+        - api_key: []
+  /store/order:
+    post:
+      tags:
+        - store
+      summary: Place an order for a pet
+      description: ""
+      operationId: placeOrder
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                $ref: "#/components/schemas/Order"
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Order"
+        "400":
+          description: Invalid Order
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Order"
+        description: order placed for purchasing the pet
+        required: true
+  "/store/order/{orderId}":
+    get:
+      tags:
+        - store
+      summary: Find purchase order by ID
+      description: For valid response try integer IDs with value >= 1 and <= 10. Other values will generated exceptions
+      operationId: getOrderById
+      parameters:
+        - name: orderId
+          in: path
+          description: ID of pet that needs to be fetched
+          required: true
+          schema:
+            type: integer
+            format: int64
+            minimum: 1
+            maximum: 10
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                $ref: "#/components/schemas/Order"
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Order"
+        "400":
+          description: Invalid ID supplied
+        "404":
+          description: Order not found
+    delete:
+      tags:
+        - store
+      summary: Delete purchase order by ID
+      description: For valid response try integer IDs with positive integer value. Negative or non-integer values will generate API errors
+      operationId: deleteOrder
+      parameters:
+        - name: orderId
+          in: path
+          description: ID of the order that needs to be deleted
+          required: true
+          schema:
+            type: integer
+            format: int64
+            minimum: 1
+      responses:
+        "400":
+          description: Invalid ID supplied
+        "404":
+          description: Order not found
+  /user:
+    post:
+      tags:
+        - user
+      summary: Create user
+      description: This can only be done by the logged in user.
+      operationId: createUser
+      responses:
+        default:
+          description: successful operation
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/User"
+        description: Created user object
+        required: true
+  /user/createWithArray:
+    post:
+      tags:
+        - user
+      summary: Creates list of users with given input array
+      description: ""
+      operationId: createUsersWithArrayInput
+      responses:
+        default:
+          description: successful operation
+      requestBody:
+        $ref: "#/components/requestBodies/UserArray"
+  /user/createWithList:
+    post:
+      tags:
+        - user
+      summary: Creates list of users with given input array
+      description: ""
+      operationId: createUsersWithListInput
+      responses:
+        default:
+          description: successful operation
+      requestBody:
+        $ref: "#/components/requestBodies/UserArray"
+  /user/login:
+    get:
+      tags:
+        - user
+      summary: Logs user into the system
+      description: ""
+      operationId: loginUser
+      parameters:
+        - name: username
+          in: query
+          description: The user name for login
+          required: true
+          schema:
+            type: string
+        - name: password
+          in: query
+          description: The password for login in clear text
+          required: true
+          schema:
+            type: string
+            format: password
+      responses:
+        "200":
+          description: successful operation
+          headers:
+            X-Rate-Limit:
+              description: calls per hour allowed by the user
+              schema:
+                type: integer
+                format: int32
+            X-Expires-After:
+              description: date in UTC when token expires
+              schema:
+                type: string
+                format: date-time
+          content:
+            application/xml:
+              schema:
+                type: string
+            application/json:
+              schema:
+                type: string
+        "400":
+          description: Invalid username/password supplied
+  /user/logout:
+    get:
+      tags:
+        - user
+      summary: Logs out current logged in user session
+      description: ""
+      operationId: logoutUser
+      responses:
+        default:
+          description: successful operation
+  "/user/{username}":
+    get:
+      tags:
+        - user
+      summary: Get user by user name
+      description: ""
+      operationId: getUserByName
+      parameters:
+        - name: username
+          in: path
+          description: "The name that needs to be fetched. Use user1 for testing. "
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                $ref: "#/components/schemas/User"
+            application/json:
+              schema:
+                $ref: "#/components/schemas/User"
+        "400":
+          description: Invalid username supplied
+        "404":
+          description: User not found
+    put:
+      tags:
+        - user
+      summary: Updated user
+      description: This can only be done by the logged in user.
+      operationId: updateUser
+      parameters:
+        - name: username
+          in: path
+          description: name that need to be updated
+          required: true
+          schema:
+            type: string
+      responses:
+        "400":
+          description: Invalid user supplied
+        "404":
+          description: User not found
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/User"
+        description: Updated user object
+        required: true
+    delete:
+      tags:
+        - user
+      summary: Delete user
+      description: This can only be done by the logged in user.
+      operationId: deleteUser
+      parameters:
+        - name: username
+          in: path
+          description: The name that needs to be deleted
+          required: true
+          schema:
+            type: string
+      responses:
+        "400":
+          description: Invalid username supplied
+        "404":
+          description: User not found
+externalDocs:
+  description: Find out more about Swagger
+  url: http://swagger.io
+components:
+  schemas:
+    Order:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        petId:
+          type: integer
+          format: int64
+        quantity:
+          type: integer
+          format: int32
+        shipDate:
+          type: string
+          format: date-time
+        status:
+          type: string
+          description: Order Status
+          enum:
+            - placed
+            - approved
+            - delivered
+        complete:
+          type: boolean
+          default: false
+      xml:
+        name: Order
+    Category:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+      xml:
+        name: Category
+    User:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        username:
+          type: string
+        firstName:
+          type: string
+        lastName:
+          type: string
+        email:
+          type: string
+        password:
+          type: string
+        phone:
+          type: string
+        userStatus:
+          type: integer
+          format: int32
+          description: User Status
+      xml:
+        name: User
+    Tag:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+      xml:
+        name: Tag
+    Pet:
+      type: object
+      required:
+        - name
+        - photoUrls
+      properties:
+        id:
+          type: integer
+          format: int64
+        category:
+          $ref: "#/components/schemas/Category"
+        name:
+          type: string
+          example: doggie
+        photoUrls:
+          type: array
+          xml:
+            name: photoUrl
+            wrapped: true
+          items:
+            type: string
+        tags:
+          type: array
+          xml:
+            name: tag
+            wrapped: true
+          items:
+            $ref: "#/components/schemas/Tag"
+        status:
+          type: string
+          description: pet status in the store
+          enum:
+            - available
+            - pending
+            - sold
+      xml:
+        name: Pet
+    ApiResponse:
+      type: object
+      properties:
+        code:
+          type: integer
+          format: int32
+        type:
+          type: string
+        message:
+          type: string
+  requestBodies:
+    Pet:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Pet"
+        application/xml:
+          schema:
+            $ref: "#/components/schemas/Pet"
+      description: Pet object that needs to be added to the store
+      required: true
+    UserArray:
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/User"
+      description: List of user object
+      required: true
+  securitySchemes:
+    petstore_auth:
+      type: oauth2
+      flows:
+        implicit:
+          authorizationUrl: http://petstore.swagger.io/oauth/dialog
+          scopes:
+            write:pets: modify pets in your account
+            read:pets: read your pets
+    api_key:
+      type: apiKey
+      name: api_key
+      in: header

--- a/test/scopes1/options.yaml
+++ b/test/scopes1/options.yaml
@@ -1,0 +1,2 @@
+flags: [ 'write:pets' ]
+checkScopes: true

--- a/test/scopes1/output.yaml
+++ b/test/scopes1/output.yaml
@@ -1,0 +1,569 @@
+openapi: 3.0.0
+servers:
+  - url: http://petstore.swagger.io/v2
+x-origin:
+  - url: http://petstore.swagger.io/v2/swagger.json
+    format: swagger
+    version: "2.0"
+    converter:
+      url: https://github.com/mermade/swagger2openapi
+      version: 2.6.3
+info:
+  description: "This is a sample server Petstore server.  You can find out more
+    about Swagger at [http://swagger.io](http://swagger.io) or on
+    [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you
+    can use the api key `special-key` to test the authorization filters."
+  version: 1.0.0
+  title: Swagger Petstore
+  termsOfService: http://swagger.io/terms/
+  contact:
+    email: apiteam@swagger.io
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+security:
+  - api_key: []
+tags:
+  - name: pet
+    description: Everything about your Pets
+    externalDocs:
+      description: Find out more
+      url: http://swagger.io
+  - name: store
+    description: Access to Petstore orders
+  - name: user
+    description: Operations about user
+    externalDocs:
+      description: Find out more about our store
+      url: http://swagger.io
+paths:
+  /pet/findByStatus:
+    get:
+      tags:
+        - pet
+      summary: Finds Pets by status
+      description: Multiple status values can be provided with comma separated strings
+      operationId: findPetsByStatus
+      parameters:
+        - name: status
+          in: query
+          description: Status values that need to be considered for filter
+          required: true
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - available
+                - pending
+                - sold
+              default: available
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Pet"
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Pet"
+        "400":
+          description: Invalid status value
+      security:
+        - petstore_auth:
+            - read:pets
+  /pet/findByTags:
+    get:
+      tags:
+        - pet
+      summary: Finds Pets by tags
+      description: Muliple tags can be provided with comma separated strings. Use
+        tag1, tag2, tag3 for testing.
+      operationId: findPetsByTags
+      parameters:
+        - name: tags
+          in: query
+          description: Tags to filter by
+          required: true
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Pet"
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Pet"
+        "400":
+          description: Invalid tag value
+      security:
+        - petstore_auth:
+            - read:pets
+      deprecated: true
+  "/pet/{petId}":
+    get:
+      tags:
+        - pet
+      summary: Find pet by ID
+      description: Returns a single pet
+      operationId: getPetById
+      parameters:
+        - name: petId
+          in: path
+          description: ID of pet to return
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                $ref: "#/components/schemas/Pet"
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+        "400":
+          description: Invalid ID supplied
+        "404":
+          description: Pet not found
+      security:
+        - api_key: []
+  /store/inventory:
+    get:
+      tags:
+        - store
+      summary: Returns pet inventories by status
+      description: Returns a map of status codes to quantities
+      operationId: getInventory
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: integer
+                  format: int32
+      security:
+        - api_key: []
+  /store/order:
+    post:
+      tags:
+        - store
+      summary: Place an order for a pet
+      description: ""
+      operationId: placeOrder
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                $ref: "#/components/schemas/Order"
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Order"
+        "400":
+          description: Invalid Order
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Order"
+        description: order placed for purchasing the pet
+        required: true
+  "/store/order/{orderId}":
+    get:
+      tags:
+        - store
+      summary: Find purchase order by ID
+      description: For valid response try integer IDs with value >= 1 and <= 10. Other
+        values will generated exceptions
+      operationId: getOrderById
+      parameters:
+        - name: orderId
+          in: path
+          description: ID of pet that needs to be fetched
+          required: true
+          schema:
+            type: integer
+            format: int64
+            minimum: 1
+            maximum: 10
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                $ref: "#/components/schemas/Order"
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Order"
+        "400":
+          description: Invalid ID supplied
+        "404":
+          description: Order not found
+    delete:
+      tags:
+        - store
+      summary: Delete purchase order by ID
+      description: For valid response try integer IDs with positive integer value.
+        Negative or non-integer values will generate API errors
+      operationId: deleteOrder
+      parameters:
+        - name: orderId
+          in: path
+          description: ID of the order that needs to be deleted
+          required: true
+          schema:
+            type: integer
+            format: int64
+            minimum: 1
+      responses:
+        "400":
+          description: Invalid ID supplied
+        "404":
+          description: Order not found
+  /user:
+    post:
+      tags:
+        - user
+      summary: Create user
+      description: This can only be done by the logged in user.
+      operationId: createUser
+      responses:
+        default:
+          description: successful operation
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/User"
+        description: Created user object
+        required: true
+  /user/createWithArray:
+    post:
+      tags:
+        - user
+      summary: Creates list of users with given input array
+      description: ""
+      operationId: createUsersWithArrayInput
+      responses:
+        default:
+          description: successful operation
+      requestBody:
+        $ref: "#/components/requestBodies/UserArray"
+  /user/createWithList:
+    post:
+      tags:
+        - user
+      summary: Creates list of users with given input array
+      description: ""
+      operationId: createUsersWithListInput
+      responses:
+        default:
+          description: successful operation
+      requestBody:
+        $ref: "#/components/requestBodies/UserArray"
+  /user/login:
+    get:
+      tags:
+        - user
+      summary: Logs user into the system
+      description: ""
+      operationId: loginUser
+      parameters:
+        - name: username
+          in: query
+          description: The user name for login
+          required: true
+          schema:
+            type: string
+        - name: password
+          in: query
+          description: The password for login in clear text
+          required: true
+          schema:
+            type: string
+            format: password
+      responses:
+        "200":
+          description: successful operation
+          headers:
+            X-Rate-Limit:
+              description: calls per hour allowed by the user
+              schema:
+                type: integer
+                format: int32
+            X-Expires-After:
+              description: date in UTC when token expires
+              schema:
+                type: string
+                format: date-time
+          content:
+            application/xml:
+              schema:
+                type: string
+            application/json:
+              schema:
+                type: string
+        "400":
+          description: Invalid username/password supplied
+  /user/logout:
+    get:
+      tags:
+        - user
+      summary: Logs out current logged in user session
+      description: ""
+      operationId: logoutUser
+      responses:
+        default:
+          description: successful operation
+  "/user/{username}":
+    get:
+      tags:
+        - user
+      summary: Get user by user name
+      description: ""
+      operationId: getUserByName
+      parameters:
+        - name: username
+          in: path
+          description: "The name that needs to be fetched. Use user1 for testing. "
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                $ref: "#/components/schemas/User"
+            application/json:
+              schema:
+                $ref: "#/components/schemas/User"
+        "400":
+          description: Invalid username supplied
+        "404":
+          description: User not found
+    put:
+      tags:
+        - user
+      summary: Updated user
+      description: This can only be done by the logged in user.
+      operationId: updateUser
+      parameters:
+        - name: username
+          in: path
+          description: name that need to be updated
+          required: true
+          schema:
+            type: string
+      responses:
+        "400":
+          description: Invalid user supplied
+        "404":
+          description: User not found
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/User"
+        description: Updated user object
+        required: true
+    delete:
+      tags:
+        - user
+      summary: Delete user
+      description: This can only be done by the logged in user.
+      operationId: deleteUser
+      parameters:
+        - name: username
+          in: path
+          description: The name that needs to be deleted
+          required: true
+          schema:
+            type: string
+      responses:
+        "400":
+          description: Invalid username supplied
+        "404":
+          description: User not found
+externalDocs:
+  description: Find out more about Swagger
+  url: http://swagger.io
+components:
+  schemas:
+    Order:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        petId:
+          type: integer
+          format: int64
+        quantity:
+          type: integer
+          format: int32
+        shipDate:
+          type: string
+          format: date-time
+        status:
+          type: string
+          description: Order Status
+          enum:
+            - placed
+            - approved
+            - delivered
+        complete:
+          type: boolean
+          default: false
+      xml:
+        name: Order
+    Category:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+      xml:
+        name: Category
+    User:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        username:
+          type: string
+        firstName:
+          type: string
+        lastName:
+          type: string
+        email:
+          type: string
+        password:
+          type: string
+        phone:
+          type: string
+        userStatus:
+          type: integer
+          format: int32
+          description: User Status
+      xml:
+        name: User
+    Tag:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+      xml:
+        name: Tag
+    Pet:
+      type: object
+      required:
+        - name
+        - photoUrls
+      properties:
+        id:
+          type: integer
+          format: int64
+        category:
+          $ref: "#/components/schemas/Category"
+        name:
+          type: string
+          example: doggie
+        photoUrls:
+          type: array
+          xml:
+            name: photoUrl
+            wrapped: true
+          items:
+            type: string
+        tags:
+          type: array
+          xml:
+            name: tag
+            wrapped: true
+          items:
+            $ref: "#/components/schemas/Tag"
+        status:
+          type: string
+          description: pet status in the store
+          enum:
+            - available
+            - pending
+            - sold
+      xml:
+        name: Pet
+    ApiResponse:
+      type: object
+      properties:
+        code:
+          type: integer
+          format: int32
+        type:
+          type: string
+        message:
+          type: string
+  requestBodies:
+    Pet:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Pet"
+        application/xml:
+          schema:
+            $ref: "#/components/schemas/Pet"
+      description: Pet object that needs to be added to the store
+      required: true
+    UserArray:
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/User"
+      description: List of user object
+      required: true
+  securitySchemes:
+    petstore_auth:
+      type: oauth2
+      flows:
+        implicit:
+          authorizationUrl: http://petstore.swagger.io/oauth/dialog
+          scopes:
+            write:pets: modify pets in your account
+            read:pets: read your pets
+    api_key:
+      type: apiKey
+      name: api_key
+      in: header

--- a/test/scopes2/input.yaml
+++ b/test/scopes2/input.yaml
@@ -1,0 +1,687 @@
+openapi: 3.0.0
+servers:
+  - url: http://petstore.swagger.io/v2
+x-origin:
+  - url: http://petstore.swagger.io/v2/swagger.json
+    format: swagger
+    version: "2.0"
+    converter:
+      url: https://github.com/mermade/swagger2openapi
+      version: 2.6.3
+info:
+  description: "This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key `special-key` to test the authorization filters."
+  version: 1.0.0
+  title: Swagger Petstore
+  termsOfService: http://swagger.io/terms/
+  contact:
+    email: apiteam@swagger.io
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+security:
+  - petstore_auth:
+      - write:pets
+tags:
+  - name: pet
+    description: Everything about your Pets
+    externalDocs:
+      description: Find out more
+      url: http://swagger.io
+  - name: store
+    description: Access to Petstore orders
+  - name: user
+    description: Operations about user
+    externalDocs:
+      description: Find out more about our store
+      url: http://swagger.io
+paths:
+  /pet:
+    post:
+      tags:
+        - pet
+      summary: Add a new pet to the store
+      description: ""
+      operationId: addPet
+      responses:
+        "405":
+          description: Invalid input
+      security:
+        - petstore_auth:
+            - write:pets
+      requestBody:
+        $ref: "#/components/requestBodies/Pet"
+    put:
+      tags:
+        - pet
+      summary: Update an existing pet
+      description: ""
+      operationId: updatePet
+      responses:
+        "400":
+          description: Invalid ID supplied
+        "404":
+          description: Pet not found
+        "405":
+          description: Validation exception
+      security:
+        - petstore_auth:
+            - write:pets
+      requestBody:
+        $ref: "#/components/requestBodies/Pet"
+  /pet/findByStatus:
+    get:
+      tags:
+        - pet
+      summary: Finds Pets by status
+      description: Multiple status values can be provided with comma separated strings
+      operationId: findPetsByStatus
+      parameters:
+        - name: status
+          in: query
+          description: Status values that need to be considered for filter
+          required: true
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - available
+                - pending
+                - sold
+              default: available
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Pet"
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Pet"
+        "400":
+          description: Invalid status value
+      security:
+        - petstore_auth:
+            - read:pets
+  /pet/findByTags:
+    get:
+      tags:
+        - pet
+      summary: Finds Pets by tags
+      description: Muliple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
+      operationId: findPetsByTags
+      parameters:
+        - name: tags
+          in: query
+          description: Tags to filter by
+          required: true
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Pet"
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Pet"
+        "400":
+          description: Invalid tag value
+      security:
+        - petstore_auth:
+            - read:pets
+      deprecated: true
+  "/pet/{petId}":
+    get:
+      tags:
+        - pet
+      summary: Find pet by ID
+      description: Returns a single pet
+      operationId: getPetById
+      parameters:
+        - name: petId
+          in: path
+          description: ID of pet to return
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                $ref: "#/components/schemas/Pet"
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+        "400":
+          description: Invalid ID supplied
+        "404":
+          description: Pet not found
+      security:
+        - api_key: []
+    post:
+      tags:
+        - pet
+      summary: Updates a pet in the store with form data
+      description: ""
+      operationId: updatePetWithForm
+      parameters:
+        - name: petId
+          in: path
+          description: ID of pet that needs to be updated
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        "405":
+          description: Invalid input
+      security:
+        - petstore_auth:
+            - write:pets
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                name:
+                  description: Updated name of the pet
+                  type: string
+                status:
+                  description: Updated status of the pet
+                  type: string
+    delete:
+      tags:
+        - pet
+      summary: Deletes a pet
+      description: ""
+      operationId: deletePet
+      parameters:
+        - name: api_key
+          in: header
+          required: false
+          schema:
+            type: string
+        - name: petId
+          in: path
+          description: Pet id to delete
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        "400":
+          description: Invalid ID supplied
+        "404":
+          description: Pet not found
+      security:
+        - petstore_auth:
+            - write:pets
+  "/pet/{petId}/uploadImage":
+    post:
+      tags:
+        - pet
+      summary: uploads an image
+      description: ""
+      operationId: uploadFile
+      parameters:
+        - name: petId
+          in: path
+          description: ID of pet to update
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiResponse"
+      security:
+        - petstore_auth:
+            - write:pets
+      requestBody:
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+  /store/inventory:
+    get:
+      tags:
+        - store
+      summary: Returns pet inventories by status
+      description: Returns a map of status codes to quantities
+      operationId: getInventory
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: integer
+                  format: int32
+      security:
+        - api_key: []
+  /store/order:
+    post:
+      tags:
+        - store
+      summary: Place an order for a pet
+      description: ""
+      operationId: placeOrder
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                $ref: "#/components/schemas/Order"
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Order"
+        "400":
+          description: Invalid Order
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Order"
+        description: order placed for purchasing the pet
+        required: true
+  "/store/order/{orderId}":
+    get:
+      tags:
+        - store
+      summary: Find purchase order by ID
+      description: For valid response try integer IDs with value >= 1 and <= 10. Other values will generated exceptions
+      operationId: getOrderById
+      parameters:
+        - name: orderId
+          in: path
+          description: ID of pet that needs to be fetched
+          required: true
+          schema:
+            type: integer
+            format: int64
+            minimum: 1
+            maximum: 10
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                $ref: "#/components/schemas/Order"
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Order"
+        "400":
+          description: Invalid ID supplied
+        "404":
+          description: Order not found
+    delete:
+      tags:
+        - store
+      summary: Delete purchase order by ID
+      description: For valid response try integer IDs with positive integer value. Negative or non-integer values will generate API errors
+      operationId: deleteOrder
+      parameters:
+        - name: orderId
+          in: path
+          description: ID of the order that needs to be deleted
+          required: true
+          schema:
+            type: integer
+            format: int64
+            minimum: 1
+      responses:
+        "400":
+          description: Invalid ID supplied
+        "404":
+          description: Order not found
+  /user:
+    post:
+      tags:
+        - user
+      summary: Create user
+      description: This can only be done by the logged in user.
+      operationId: createUser
+      responses:
+        default:
+          description: successful operation
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/User"
+        description: Created user object
+        required: true
+  /user/createWithArray:
+    post:
+      tags:
+        - user
+      summary: Creates list of users with given input array
+      description: ""
+      operationId: createUsersWithArrayInput
+      responses:
+        default:
+          description: successful operation
+      requestBody:
+        $ref: "#/components/requestBodies/UserArray"
+  /user/createWithList:
+    post:
+      tags:
+        - user
+      summary: Creates list of users with given input array
+      description: ""
+      operationId: createUsersWithListInput
+      responses:
+        default:
+          description: successful operation
+      requestBody:
+        $ref: "#/components/requestBodies/UserArray"
+  /user/login:
+    get:
+      tags:
+        - user
+      summary: Logs user into the system
+      description: ""
+      operationId: loginUser
+      parameters:
+        - name: username
+          in: query
+          description: The user name for login
+          required: true
+          schema:
+            type: string
+        - name: password
+          in: query
+          description: The password for login in clear text
+          required: true
+          schema:
+            type: string
+            format: password
+      responses:
+        "200":
+          description: successful operation
+          headers:
+            X-Rate-Limit:
+              description: calls per hour allowed by the user
+              schema:
+                type: integer
+                format: int32
+            X-Expires-After:
+              description: date in UTC when token expires
+              schema:
+                type: string
+                format: date-time
+          content:
+            application/xml:
+              schema:
+                type: string
+            application/json:
+              schema:
+                type: string
+        "400":
+          description: Invalid username/password supplied
+  /user/logout:
+    get:
+      tags:
+        - user
+      summary: Logs out current logged in user session
+      description: ""
+      operationId: logoutUser
+      responses:
+        default:
+          description: successful operation
+  "/user/{username}":
+    get:
+      tags:
+        - user
+      summary: Get user by user name
+      description: ""
+      operationId: getUserByName
+      parameters:
+        - name: username
+          in: path
+          description: "The name that needs to be fetched. Use user1 for testing. "
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                $ref: "#/components/schemas/User"
+            application/json:
+              schema:
+                $ref: "#/components/schemas/User"
+        "400":
+          description: Invalid username supplied
+        "404":
+          description: User not found
+    put:
+      tags:
+        - user
+      summary: Updated user
+      description: This can only be done by the logged in user.
+      operationId: updateUser
+      parameters:
+        - name: username
+          in: path
+          description: name that need to be updated
+          required: true
+          schema:
+            type: string
+      responses:
+        "400":
+          description: Invalid user supplied
+        "404":
+          description: User not found
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/User"
+        description: Updated user object
+        required: true
+    delete:
+      tags:
+        - user
+      summary: Delete user
+      description: This can only be done by the logged in user.
+      operationId: deleteUser
+      parameters:
+        - name: username
+          in: path
+          description: The name that needs to be deleted
+          required: true
+          schema:
+            type: string
+      responses:
+        "400":
+          description: Invalid username supplied
+        "404":
+          description: User not found
+externalDocs:
+  description: Find out more about Swagger
+  url: http://swagger.io
+components:
+  schemas:
+    Order:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        petId:
+          type: integer
+          format: int64
+        quantity:
+          type: integer
+          format: int32
+        shipDate:
+          type: string
+          format: date-time
+        status:
+          type: string
+          description: Order Status
+          enum:
+            - placed
+            - approved
+            - delivered
+        complete:
+          type: boolean
+          default: false
+      xml:
+        name: Order
+    Category:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+      xml:
+        name: Category
+    User:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        username:
+          type: string
+        firstName:
+          type: string
+        lastName:
+          type: string
+        email:
+          type: string
+        password:
+          type: string
+        phone:
+          type: string
+        userStatus:
+          type: integer
+          format: int32
+          description: User Status
+      xml:
+        name: User
+    Tag:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+      xml:
+        name: Tag
+    Pet:
+      type: object
+      required:
+        - name
+        - photoUrls
+      properties:
+        id:
+          type: integer
+          format: int64
+        category:
+          $ref: "#/components/schemas/Category"
+        name:
+          type: string
+          example: doggie
+        photoUrls:
+          type: array
+          xml:
+            name: photoUrl
+            wrapped: true
+          items:
+            type: string
+        tags:
+          type: array
+          xml:
+            name: tag
+            wrapped: true
+          items:
+            $ref: "#/components/schemas/Tag"
+        status:
+          type: string
+          description: pet status in the store
+          enum:
+            - available
+            - pending
+            - sold
+      xml:
+        name: Pet
+    ApiResponse:
+      type: object
+      properties:
+        code:
+          type: integer
+          format: int32
+        type:
+          type: string
+        message:
+          type: string
+  requestBodies:
+    Pet:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Pet"
+        application/xml:
+          schema:
+            $ref: "#/components/schemas/Pet"
+      description: Pet object that needs to be added to the store
+      required: true
+    UserArray:
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/User"
+      description: List of user object
+      required: true
+  securitySchemes:
+    petstore_auth:
+      type: oauth2
+      flows:
+        implicit:
+          authorizationUrl: http://petstore.swagger.io/oauth/dialog
+          scopes:
+            write:pets: modify pets in your account
+            read:pets: read your pets
+    api_key:
+      type: apiKey
+      name: api_key
+      in: header

--- a/test/scopes2/options.yaml
+++ b/test/scopes2/options.yaml
@@ -1,0 +1,2 @@
+flags: [ 'write:pets' ]
+checkScopes: true

--- a/test/scopes2/output.yaml
+++ b/test/scopes2/output.yaml
@@ -1,0 +1,325 @@
+openapi: 3.0.0
+servers:
+  - url: http://petstore.swagger.io/v2
+x-origin:
+  - url: http://petstore.swagger.io/v2/swagger.json
+    format: swagger
+    version: "2.0"
+    converter:
+      url: https://github.com/mermade/swagger2openapi
+      version: 2.6.3
+info:
+  description: "This is a sample server Petstore server.  You can find out more
+    about Swagger at [http://swagger.io](http://swagger.io) or on
+    [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you
+    can use the api key `special-key` to test the authorization filters."
+  version: 1.0.0
+  title: Swagger Petstore
+  termsOfService: http://swagger.io/terms/
+  contact:
+    email: apiteam@swagger.io
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+security:
+  - petstore_auth:
+      - write:pets
+tags:
+  - name: pet
+    description: Everything about your Pets
+    externalDocs:
+      description: Find out more
+      url: http://swagger.io
+  - name: store
+    description: Access to Petstore orders
+  - name: user
+    description: Operations about user
+    externalDocs:
+      description: Find out more about our store
+      url: http://swagger.io
+paths:
+  /pet/findByStatus:
+    get:
+      tags:
+        - pet
+      summary: Finds Pets by status
+      description: Multiple status values can be provided with comma separated strings
+      operationId: findPetsByStatus
+      parameters:
+        - name: status
+          in: query
+          description: Status values that need to be considered for filter
+          required: true
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - available
+                - pending
+                - sold
+              default: available
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Pet"
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Pet"
+        "400":
+          description: Invalid status value
+      security:
+        - petstore_auth:
+            - read:pets
+  /pet/findByTags:
+    get:
+      tags:
+        - pet
+      summary: Finds Pets by tags
+      description: Muliple tags can be provided with comma separated strings. Use
+        tag1, tag2, tag3 for testing.
+      operationId: findPetsByTags
+      parameters:
+        - name: tags
+          in: query
+          description: Tags to filter by
+          required: true
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Pet"
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Pet"
+        "400":
+          description: Invalid tag value
+      security:
+        - petstore_auth:
+            - read:pets
+      deprecated: true
+  "/pet/{petId}":
+    get:
+      tags:
+        - pet
+      summary: Find pet by ID
+      description: Returns a single pet
+      operationId: getPetById
+      parameters:
+        - name: petId
+          in: path
+          description: ID of pet to return
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                $ref: "#/components/schemas/Pet"
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+        "400":
+          description: Invalid ID supplied
+        "404":
+          description: Pet not found
+      security:
+        - api_key: []
+  /store/inventory:
+    get:
+      tags:
+        - store
+      summary: Returns pet inventories by status
+      description: Returns a map of status codes to quantities
+      operationId: getInventory
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: integer
+                  format: int32
+      security:
+        - api_key: []
+externalDocs:
+  description: Find out more about Swagger
+  url: http://swagger.io
+components:
+  schemas:
+    Order:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        petId:
+          type: integer
+          format: int64
+        quantity:
+          type: integer
+          format: int32
+        shipDate:
+          type: string
+          format: date-time
+        status:
+          type: string
+          description: Order Status
+          enum:
+            - placed
+            - approved
+            - delivered
+        complete:
+          type: boolean
+          default: false
+      xml:
+        name: Order
+    Category:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+      xml:
+        name: Category
+    User:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        username:
+          type: string
+        firstName:
+          type: string
+        lastName:
+          type: string
+        email:
+          type: string
+        password:
+          type: string
+        phone:
+          type: string
+        userStatus:
+          type: integer
+          format: int32
+          description: User Status
+      xml:
+        name: User
+    Tag:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+      xml:
+        name: Tag
+    Pet:
+      type: object
+      required:
+        - name
+        - photoUrls
+      properties:
+        id:
+          type: integer
+          format: int64
+        category:
+          $ref: "#/components/schemas/Category"
+        name:
+          type: string
+          example: doggie
+        photoUrls:
+          type: array
+          xml:
+            name: photoUrl
+            wrapped: true
+          items:
+            type: string
+        tags:
+          type: array
+          xml:
+            name: tag
+            wrapped: true
+          items:
+            $ref: "#/components/schemas/Tag"
+        status:
+          type: string
+          description: pet status in the store
+          enum:
+            - available
+            - pending
+            - sold
+      xml:
+        name: Pet
+    ApiResponse:
+      type: object
+      properties:
+        code:
+          type: integer
+          format: int32
+        type:
+          type: string
+        message:
+          type: string
+  requestBodies:
+    Pet:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Pet"
+        application/xml:
+          schema:
+            $ref: "#/components/schemas/Pet"
+      description: Pet object that needs to be added to the store
+      required: true
+    UserArray:
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/User"
+      description: List of user object
+      required: true
+  securitySchemes:
+    petstore_auth:
+      type: oauth2
+      flows:
+        implicit:
+          authorizationUrl: http://petstore.swagger.io/oauth/dialog
+          scopes:
+            write:pets: modify pets in your account
+            read:pets: read your pets
+    api_key:
+      type: apiKey
+      name: api_key
+      in: header


### PR DESCRIPTION
In a non-trivial set of APIs with complex OAuth scopes;  some clients want a 'simplified' openapi spec that covers just the stuff they're allowed to do.

So let's filter by `--scopes` allowing us to prune away the operations they're not allowed.  

Recognised HTTP operations that don't have `security` element will be filtered based upon global `security` element as expected.