### PR TITLE
Feature - Option to specify a config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Options:
   --maxAliasCount  maximum YAML aliases allowed          [number] [default: 100]
   --configFile     The file & path for the filter options                 [path]
   --help           Show help                                           [boolean]
-  --verbose        Output more details of the filter process           [boolean]
+  --verbose        Output more details of the filter process             [count]
 ```
 
 use `--` to separate flags or other array options from following options, i.e.:

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Options:
   --servers        include complete servers object with --valid        [boolean]
   --lineWidth, -l  max line width of yaml output          [number] [default: -1]
   --maxAliasCount  maximum YAML aliases allowed          [number] [default: 100]
+  --configFile     The file & path for the filter options                 [path]
   --help           Show help                                           [boolean]
 ```
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Options:
   --maxAliasCount  maximum YAML aliases allowed          [number] [default: 100]
   --configFile     The file & path for the filter options                 [path]
   --help           Show help                                           [boolean]
+  --verbose        Output more details of the filter process           [boolean]
 ```
 
 use `--` to separate flags or other array options from following options, i.e.:

--- a/openapi-filter.js
+++ b/openapi-filter.js
@@ -49,17 +49,24 @@ let argv = require('yargs')
     .describe('maxAliasCount','maximum YAML aliases allowed')
     .alias('configFile', 'c')
     .describe('configFile', 'The file & path for the filter options')
-    .boolean('verbose')
-    .describe('verbose', 'Output more details of the filter process')
+    .count('verbose')
+    .describe('verbose', 'Output more details of the filter process.')
     .help()
     .version()
     .argv;
 
-if (argv.verbose) console.warn('=== Document filtering started ===','\n')
+// Helper function to display info message, depending on the verbose level
+function INFO(msg) {
+    if (argv.verbose >= 1) {
+        console.warn(msg)
+    }
+}
+
+INFO('=== Document filtering started ===\n')
 
 // apply options from config file if present
 if (argv && argv.configFile) {
-    if (argv.verbose) console.warn('CONFIG File:  ' + argv.configFile)
+    INFO('CONFIG File:  ' + argv.configFile)
     try {
         let configFileOptions = {}
         if (argv.configFile.indexOf('.json')>=0) {
@@ -72,7 +79,8 @@ if (argv && argv.configFile) {
         console.error(err)
     }
 }
-if (argv.verbose) console.warn('IN File:      ' + argv.infile)
+
+INFO('IN File:      ' + argv.infile)
 
 let s = fs.readFileSync(argv.infile,'utf8');
 let obj = yaml.parse(s, {maxAliasCount: argv.maxAliasCount});
@@ -87,10 +95,11 @@ else {
 if (argv.outfile) {
     fs.writeFileSync(argv.outfile,s,'utf8');
 
-    if (argv.verbose) console.warn('OUT File:     ' + argv.outfile)
+    INFO('OUT File:     ' + argv.outfile)
 }
 else {
     console.log(s);
 }
-if (argv.verbose) console.warn('\n','✅ Document was filtered successfully!')
+
+INFO('\n✅ Document was filtered successfully!')
 

--- a/openapi-filter.js
+++ b/openapi-filter.js
@@ -47,9 +47,22 @@ let argv = require('yargs')
     .number('maxAliasCount')
     .default('maxAliasCount',100)
     .describe('maxAliasCount','maximum YAML aliases allowed')
+    .alias('configFile', 'c')
+    .describe('configFile', 'The file & path for the filter options')
     .help()
     .version()
     .argv;
+
+// apply options from config file if present
+if (argv && argv.configFile) {
+    console.log('Options Config file used: ', argv.configFile);
+    try {
+        let configFileOptions = JSON.parse(fs.readFileSync(argv.configFile, 'utf8'));
+        argv = Object.assign({}, argv, configFileOptions);
+    } catch (err) {
+        console.error(err)
+    }
+}
 
 let s = fs.readFileSync(argv.infile,'utf8');
 let obj = yaml.parse(s, {maxAliasCount: argv.maxAliasCount});

--- a/openapi-filter.js
+++ b/openapi-filter.js
@@ -55,7 +55,7 @@ let argv = require('yargs')
     .version()
     .argv;
 
-if (argv.verbose) console.info('=== OpenAPI document fltering started ===','\n')
+if (argv.verbose) console.warn('=== Document filtering started ===','\n')
 
 // apply options from config file if present
 if (argv && argv.configFile) {
@@ -72,7 +72,7 @@ if (argv && argv.configFile) {
         console.error(err)
     }
 }
-if (argv.verbose) console.info('IN File:      ' + argv.infile)
+if (argv.verbose) console.warn('IN File:      ' + argv.infile)
 
 let s = fs.readFileSync(argv.infile,'utf8');
 let obj = yaml.parse(s, {maxAliasCount: argv.maxAliasCount});
@@ -87,10 +87,10 @@ else {
 if (argv.outfile) {
     fs.writeFileSync(argv.outfile,s,'utf8');
 
-    if (argv.verbose) console.info('OUT File:     ' + argv.outfile)
+    if (argv.verbose) console.warn('OUT File:     ' + argv.outfile)
 }
 else {
     console.log(s);
 }
-if (argv.verbose) console.info('\x1b[32m%s\x1b[0m','\n','✅ OpenAPI document was filtered successful!')
+if (argv.verbose) console.warn('\n','✅ Document was filtered successfully!')
 

--- a/openapi-filter.js
+++ b/openapi-filter.js
@@ -55,11 +55,11 @@ let argv = require('yargs')
     .version()
     .argv;
 
-if(argv.verbose) console.info('=== OpenAPI document fltering started ===','\n')
+if (argv.verbose) console.info('=== OpenAPI document fltering started ===','\n')
 
 // apply options from config file if present
 if (argv && argv.configFile) {
-    if(argv.verbose) console.warn('CONFIG File:  ' + argv.configFile)
+    if (argv.verbose) console.warn('CONFIG File:  ' + argv.configFile)
     try {
         let configFileOptions = {}
         if (argv.configFile.indexOf('.json')>=0) {
@@ -72,7 +72,7 @@ if (argv && argv.configFile) {
         console.error(err)
     }
 }
-if(argv.verbose) console.info('IN File:      ' + argv.infile)
+if (argv.verbose) console.info('IN File:      ' + argv.infile)
 
 let s = fs.readFileSync(argv.infile,'utf8');
 let obj = yaml.parse(s, {maxAliasCount: argv.maxAliasCount});
@@ -87,10 +87,10 @@ else {
 if (argv.outfile) {
     fs.writeFileSync(argv.outfile,s,'utf8');
 
-    if(argv.verbose) console.info('OUT File:     ' + argv.outfile)
+    if (argv.verbose) console.info('OUT File:     ' + argv.outfile)
 }
 else {
     console.log(s);
 }
-if(argv.verbose) console.info('\x1b[32m%s\x1b[0m','\n','✅ OpenAPI document was filtered successful!')
+if (argv.verbose) console.info('\x1b[32m%s\x1b[0m','\n','✅ OpenAPI document was filtered successful!')
 

--- a/openapi-filter.js
+++ b/openapi-filter.js
@@ -55,9 +55,13 @@ let argv = require('yargs')
 
 // apply options from config file if present
 if (argv && argv.configFile) {
-    console.log('Options Config file used: ', argv.configFile);
     try {
-        let configFileOptions = JSON.parse(fs.readFileSync(argv.configFile, 'utf8'));
+        let configFileOptions = {}
+        if (argv.configFile.indexOf('.json')>=0) {
+            configFileOptions = JSON.parse(fs.readFileSync(argv.configFile, 'utf8'));
+        } else {
+            configFileOptions = yaml.parse(fs.readFileSync(argv.configFile, 'utf8'), {schema:'core'});
+        }
         argv = Object.assign({}, argv, configFileOptions);
     } catch (err) {
         console.error(err)

--- a/openapi-filter.js
+++ b/openapi-filter.js
@@ -49,12 +49,17 @@ let argv = require('yargs')
     .describe('maxAliasCount','maximum YAML aliases allowed')
     .alias('configFile', 'c')
     .describe('configFile', 'The file & path for the filter options')
+    .boolean('verbose')
+    .describe('verbose', 'Output more details of the filter process')
     .help()
     .version()
     .argv;
 
+if(argv.verbose) console.info('=== OpenAPI document fltering started ===','\n')
+
 // apply options from config file if present
 if (argv && argv.configFile) {
+    if(argv.verbose) console.warn('CONFIG File:  ' + argv.configFile)
     try {
         let configFileOptions = {}
         if (argv.configFile.indexOf('.json')>=0) {
@@ -67,6 +72,7 @@ if (argv && argv.configFile) {
         console.error(err)
     }
 }
+if(argv.verbose) console.info('IN File:      ' + argv.infile)
 
 let s = fs.readFileSync(argv.infile,'utf8');
 let obj = yaml.parse(s, {maxAliasCount: argv.maxAliasCount});
@@ -80,8 +86,11 @@ else {
 }
 if (argv.outfile) {
     fs.writeFileSync(argv.outfile,s,'utf8');
+
+    if(argv.verbose) console.info('OUT File:     ' + argv.outfile)
 }
 else {
     console.log(s);
 }
+if(argv.verbose) console.info('\x1b[32m%s\x1b[0m','\n','✅ OpenAPI document was filtered successful!')
 

--- a/test/configFile/input.yaml
+++ b/test/configFile/input.yaml
@@ -1,0 +1,86 @@
+swagger: '2.0'
+schemes:
+  - http
+host: xkcd.com
+basePath: /
+info:
+  description: 'Webcomic of romance, sarcasm, math, and language.'
+  title: XKCD
+  version: 1.0.0
+  x-apisguru-categories:
+    - media
+  x-logo:
+    url: 'http://imgs.xkcd.com/static/terrible_small_logo.png'
+    x-internal: true
+  x-origin:
+    - format: swagger
+      url: 'https://raw.githubusercontent.com/APIs-guru/unofficial_openapi_specs/master/xkcd.com/1.0.0/swagger.yaml'
+      version: '2.0'
+  x-providerName: xkcd.com
+  x-tags:
+    - humor
+    - comics
+  x-unofficialSpec: true
+externalDocs:
+  url: 'https://xkcd.com/json.html'
+securityDefinitions: {}
+paths:
+  /info.0.json:
+    get:
+      description: |
+        Fetch current comic and metadata.
+      parameters:
+        - $ref: '#/definitions/comic'
+        - $ref: '#/definitions/hovertext'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/comic'
+  '/{comicId}/info.0.json':
+    x-internal: true
+    get:
+      description: |
+        Fetch comics and metadata by comic id.
+      parameters:
+        - in: path
+          name: comicId
+          required: true
+          type: number
+        - $ref: '#/definitions/hovertext'
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/comic'
+definitions:
+  comic:
+    properties:
+      alt:
+        type: string
+      day:
+        type: string
+      img:
+        type: string
+      link:
+        type: string
+      month:
+        type: string
+      news:
+        type: string
+      num:
+        type: number
+      safe_title:
+        type: string
+      title:
+        type: string
+      transcript:
+        type: string
+      year:
+        type: string
+    type: object
+  hovertext:
+    x-internal: true
+    properties:
+      description:
+        type: string

--- a/test/configFile/input.yaml
+++ b/test/configFile/input.yaml
@@ -1,86 +1,87 @@
 swagger: '2.0'
 schemes:
-  - http
+    - http
 host: xkcd.com
 basePath: /
 info:
-  description: 'Webcomic of romance, sarcasm, math, and language.'
-  title: XKCD
-  version: 1.0.0
-  x-apisguru-categories:
-    - media
-  x-logo:
-    url: 'http://imgs.xkcd.com/static/terrible_small_logo.png'
-    x-internal: true
-  x-origin:
-    - format: swagger
-      url: 'https://raw.githubusercontent.com/APIs-guru/unofficial_openapi_specs/master/xkcd.com/1.0.0/swagger.yaml'
-      version: '2.0'
-  x-providerName: xkcd.com
-  x-tags:
-    - humor
-    - comics
-  x-unofficialSpec: true
+    description: 'Webcomic of romance, sarcasm, math, and language.'
+    title: XKCD
+    version: 1.0.0
+    x-apisguru-categories:
+        - media
+    x-logo:
+        url: 'http://imgs.xkcd.com/static/terrible_small_logo.png'
+        x-visibility: private
+    x-origin:
+        - format: swagger
+          url: 'https://raw.githubusercontent.com/APIs-guru/unofficial_openapi_specs/master/xkcd.com/1.0.0/swagger.yaml'
+          version: '2.0'
+    x-providerName: xkcd.com
+    x-tags:
+        - humor
+        - comics
+    x-unofficialSpec: true
 externalDocs:
-  url: 'https://xkcd.com/json.html'
+    url: 'https://xkcd.com/json.html'
 securityDefinitions: {}
 paths:
-  /info.0.json:
-    get:
-      description: |
-        Fetch current comic and metadata.
-      parameters:
-        - $ref: '#/definitions/comic'
-        - $ref: '#/definitions/hovertext'
-      responses:
-        '200':
-          description: OK
-          schema:
-            $ref: '#/definitions/comic'
-  '/{comicId}/info.0.json':
-    x-internal: true
-    get:
-      description: |
-        Fetch comics and metadata by comic id.
-      parameters:
-        - in: path
-          name: comicId
-          required: true
-          type: number
-        - $ref: '#/definitions/hovertext'
-      responses:
-        '200':
-          description: OK
-          schema:
-            $ref: '#/definitions/comic'
+    /info.0.json:
+        x-visibility: public
+        get:
+            description: |
+                Fetch current comic and metadata.
+            parameters:
+                - $ref: '#/definitions/comic'
+                - $ref: '#/definitions/hovertext'
+            responses:
+                '200':
+                    description: OK
+                    schema:
+                        $ref: '#/definitions/comic'
+    '/{comicId}/info.0.json':
+        x-visibility: internal
+        get:
+            description: |
+                Fetch comics and metadata by comic id.
+            parameters:
+                - in: path
+                  name: comicId
+                  required: true
+                  type: number
+                - $ref: '#/definitions/hovertext'
+            responses:
+                '200':
+                    description: OK
+                    schema:
+                        $ref: '#/definitions/comic'
 definitions:
-  comic:
-    properties:
-      alt:
-        type: string
-      day:
-        type: string
-      img:
-        type: string
-      link:
-        type: string
-      month:
-        type: string
-      news:
-        type: string
-      num:
-        type: number
-      safe_title:
-        type: string
-      title:
-        type: string
-      transcript:
-        type: string
-      year:
-        type: string
-    type: object
-  hovertext:
-    x-internal: true
-    properties:
-      description:
-        type: string
+    comic:
+        properties:
+            alt:
+                type: string
+            day:
+                type: string
+            img:
+                type: string
+            link:
+                type: string
+            month:
+                type: string
+            news:
+                type: string
+            num:
+                type: number
+            safe_title:
+                type: string
+            title:
+                type: string
+            transcript:
+                type: string
+            year:
+                type: string
+        type: object
+    hovertext:
+        x-visibility: private
+        properties:
+            description:
+                type: string

--- a/test/configFile/options.json
+++ b/test/configFile/options.json
@@ -1,4 +1,10 @@
 {
     "version": 1.0,
-    "inverse": true
+    "flags": [
+        "x-visibility"
+    ],
+    "flagValues": [
+        "private",
+        "internal"
+    ]
 }

--- a/test/configFile/options.json
+++ b/test/configFile/options.json
@@ -1,0 +1,4 @@
+{
+    "version": 1.0,
+    "inverse": true
+}

--- a/test/configFile/options.yaml
+++ b/test/configFile/options.yaml
@@ -1,0 +1,2 @@
+inverse: true
+valid: true

--- a/test/configFile/options.yaml
+++ b/test/configFile/options.yaml
@@ -1,2 +1,0 @@
-inverse: true
-valid: true

--- a/test/configFile/output.yaml
+++ b/test/configFile/output.yaml
@@ -1,27 +1,62 @@
+swagger: "2.0"
+schemes:
+  - http
+host: xkcd.com
+basePath: /
 info:
-  x-logo:
-    url: http://imgs.xkcd.com/static/terrible_small_logo.png
-    x-internal: true
+  description: Webcomic of romance, sarcasm, math, and language.
+  title: XKCD
+  version: 1.0.0
+  x-apisguru-categories:
+    - media
+  x-origin:
+    - format: swagger
+      url: https://raw.githubusercontent.com/APIs-guru/unofficial_openapi_specs/master/xkcd.com/1.0.0/swagger.yaml
+      version: "2.0"
+  x-providerName: xkcd.com
+  x-tags:
+    - humor
+    - comics
+  x-unofficialSpec: true
+externalDocs:
+  url: https://xkcd.com/json.html
+securityDefinitions: {}
 paths:
-  "/{comicId}/info.0.json":
-    x-internal: true
+  /info.0.json:
+    x-visibility: public
     get:
       description: >
-        Fetch comics and metadata by comic id.
+        Fetch current comic and metadata.
       parameters:
-        - in: path
-          name: comicId
-          required: true
-          type: number
-        - $ref: "#/definitions/hovertext"
+        - $ref: "#/definitions/comic"
       responses:
         "200":
           description: OK
           schema:
             $ref: "#/definitions/comic"
 definitions:
-  hovertext:
-    x-internal: true
+  comic:
     properties:
-      description:
+      alt:
         type: string
+      day:
+        type: string
+      img:
+        type: string
+      link:
+        type: string
+      month:
+        type: string
+      news:
+        type: string
+      num:
+        type: number
+      safe_title:
+        type: string
+      title:
+        type: string
+      transcript:
+        type: string
+      year:
+        type: string
+    type: object

--- a/test/configFile/output.yaml
+++ b/test/configFile/output.yaml
@@ -1,0 +1,27 @@
+info:
+  x-logo:
+    url: http://imgs.xkcd.com/static/terrible_small_logo.png
+    x-internal: true
+paths:
+  "/{comicId}/info.0.json":
+    x-internal: true
+    get:
+      description: >
+        Fetch comics and metadata by comic id.
+      parameters:
+        - in: path
+          name: comicId
+          required: true
+          type: number
+        - $ref: "#/definitions/hovertext"
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: "#/definitions/comic"
+definitions:
+  hovertext:
+    x-internal: true
+    properties:
+      description:
+        type: string

--- a/test/test.js
+++ b/test/test.js
@@ -18,10 +18,20 @@ tests.forEach((test) => {
     describe(test, () => {
         it('should match expected output', (done) => {
             let options = {};
+            let configFile = null
             try {
-                options = yaml.parse(fs.readFileSync(path.join(__dirname, test, 'options.yaml'),'utf8'), {schema:'core'});
+                // Load options.yaml
+                configFile = path.join(__dirname, test, 'options.yaml');
+                options = yaml.parse(fs.readFileSync(configFile, 'utf8'), {schema: 'core'});
+            } catch (ex) {
+                try {
+                    // Fallback to options.json
+                    configFile = path.join(__dirname, test, 'options.json');
+                    options = JSON.parse(fs.readFileSync(configFile, 'utf8'));
+                } catch (ex) {
+                    // No options found. options = {} will be used
+                }
             }
-            catch (ex) {};
 
             if (options.maxAliasCount) {
                 yaml.defaultOptions.maxAliasCount = options.maxAliasCount;
@@ -34,7 +44,7 @@ tests.forEach((test) => {
               output = yaml.parse(fs.readFileSync(path.join(__dirname, test, 'output.yaml'),'utf8'), {schema:'core'});
               readOutput = true;
             }
-            catch (ex) {};
+            catch (ex) {}
 
             const result = filter.filter(input, options);
             if (!readOutput) {


### PR DESCRIPTION
A PR proposal based on #72 

Right now the options have to be passed as arguments to the CLI.

This works fine for when you have a limited set of options to set, but if you want to filter out a large number of methods/operationIds, it would make more sense to provide a "options" file as a parameter.

something like `--configFile ./config/openapi-filter-options.json`

Which would results in

`openapi-filter source.yaml target.yaml --configFile ./config/openapi-filter-options.json`

Looking forward for any feedback or remarks to improve.