### PR TITLE
Fix recursive iteration while removing - fixes #85

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,9 +63,12 @@ function filter(obj,options) {
     });
 
     recurse(src,{},function(obj,key,state){
-        if (obj.hasOwnProperty('$ref') && filteredpaths.includes(obj.$ref)) {
-            if (Array.isArray(state.parent)) {
-                state.parent.splice(state.pkey, 1);
+        if (Array.isArray(obj) && obj.length > 0) {
+            for (let idx = 0; idx < obj.length; idx++) {
+                if (obj[idx] && obj[idx].hasOwnProperty('$ref') && filteredpaths.includes(obj[idx].$ref)) {
+                    obj.splice(idx, 1);
+                    idx--;
+                }
             }
         }
     });

--- a/test/issue85/input.yaml
+++ b/test/issue85/input.yaml
@@ -1,0 +1,38 @@
+openapi: 3.0.0
+info:
+  title: API
+  version: 1.0.0
+paths:
+  /test:
+    post:
+      parameters:
+        - $ref: '#/components/parameters/InternalHeader'
+        - $ref: '#/components/parameters/SecondInternalHeader'
+        - $ref: '#/components/parameters/ExternalHeader'
+        - $ref: '#/components/parameters/ThirdInternalHeader'
+
+components:
+  parameters:
+    InternalHeader:
+      x-internal: true
+      in: header
+      name: X-Internal-Header
+      schema:
+        type: string
+    SecondInternalHeader:
+      x-internal: true
+      in: header
+      name: X-Second-Internal-Header
+      schema:
+        type: string
+    ThirdInternalHeader:
+      x-internal: true
+      in: header
+      name: X-Third-Internal-Header
+      schema:
+        type: string
+    ExternalHeader:
+      in: header
+      name: X-External-Header
+      schema:
+        type: string

--- a/test/issue85/options.yaml
+++ b/test/issue85/options.yaml
@@ -1,0 +1,1 @@
+maxAliasCount: 200

--- a/test/issue85/output.yaml
+++ b/test/issue85/output.yaml
@@ -1,0 +1,17 @@
+openapi: 3.0.0
+info:
+  title: API
+  version: 1.0.0
+paths:
+  /test:
+    post:
+      parameters:
+        - $ref: '#/components/parameters/ExternalHeader'
+
+components:
+  parameters:
+    ExternalHeader:
+      in: header
+      name: X-External-Header
+      schema:
+        type: string


### PR DESCRIPTION
This pr should fix #85.

The problem was that the recursive function basically skipped one index in the array because of the splice().
Therefore every second $ref that should be removed would be skipped.

Let me know what you think of this fix.